### PR TITLE
feat: add Hermes notification outbox clean branch

### DIFF
--- a/db/migrations/273_notification_outbox.sql
+++ b/db/migrations/273_notification_outbox.sql
@@ -1,0 +1,74 @@
+-- MIGRATION_KIND: schema
+-- SAFETY: Additive CRM-side notification outbox for Hermes task delivery. No existing data is modified and no delivery worker is activated by this migration.
+-- ROLLBACK: After confirming no Hermes worker depends on queued notifications, DROP INDEX IF EXISTS idx_notification_outbox_semantic_unique, idx_notification_outbox_event_id, idx_notification_outbox_created_at, idx_notification_outbox_event_type, idx_notification_outbox_owner_user_id, idx_notification_outbox_task_id, idx_notification_outbox_status_available; DROP TABLE IF EXISTS notification_outbox.
+
+CREATE TABLE IF NOT EXISTS notification_outbox (
+    id BIGSERIAL PRIMARY KEY,
+    event_id TEXT NOT NULL,
+    task_id BIGINT NOT NULL,
+    owner_user_id INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    payload_hash TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    available_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    claimed_at TIMESTAMPTZ,
+    sent_at TIMESTAMPTZ,
+    last_error TEXT,
+    last_error_code TEXT,
+    last_delivery_channel TEXT,
+    last_delivery_target TEXT,
+    claimed_by TEXT,
+    locked_until TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT notification_outbox_event_id_check
+        CHECK (NULLIF(BTRIM(event_id), '') IS NOT NULL),
+    CONSTRAINT notification_outbox_task_id_check
+        CHECK (task_id > 0),
+    CONSTRAINT notification_outbox_owner_user_id_check
+        CHECK (owner_user_id > 0),
+    CONSTRAINT notification_outbox_event_type_check
+        CHECK (event_type IN (
+            'task_created',
+            'task_assigned',
+            'task_reminder_due',
+            'task_overdue',
+            'task_updated'
+        )),
+    CONSTRAINT notification_outbox_payload_hash_check
+        CHECK (NULLIF(BTRIM(payload_hash), '') IS NOT NULL),
+    CONSTRAINT notification_outbox_status_check
+        CHECK (status IN (
+            'pending',
+            'claimed',
+            'sent',
+            'failed',
+            'dead_letter',
+            'skipped'
+        )),
+    CONSTRAINT notification_outbox_attempts_check
+        CHECK (attempts >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_outbox_event_id
+    ON notification_outbox(event_id);
+
+CREATE INDEX IF NOT EXISTS idx_notification_outbox_status_available
+    ON notification_outbox(status, available_at);
+
+CREATE INDEX IF NOT EXISTS idx_notification_outbox_task_id
+    ON notification_outbox(task_id);
+
+CREATE INDEX IF NOT EXISTS idx_notification_outbox_owner_user_id
+    ON notification_outbox(owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_notification_outbox_event_type
+    ON notification_outbox(event_type);
+
+CREATE INDEX IF NOT EXISTS idx_notification_outbox_created_at
+    ON notification_outbox(created_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_outbox_semantic_unique
+    ON notification_outbox(task_id, owner_user_id, event_type, payload_hash);

--- a/docs/hermes-notification-outbox-e2e-smoke-plan.md
+++ b/docs/hermes-notification-outbox-e2e-smoke-plan.md
@@ -1,0 +1,222 @@
+# Event Genix Hermes notification_outbox E2E Smoke Plan
+
+Status: plan only, not executed.
+
+This document prepares a future approval-gated end-to-end smoke for Hermes
+native task DM delivery through CRM `notification_outbox`.
+
+## Goal
+
+Verify this future path exactly once:
+
+```text
+real test CRM task
+  -> notification_outbox event created
+  -> Hermes sends exactly one Telegram DM
+  -> CRM outbox ack status=sent
+```
+
+This smoke must prove Hermes-native delivery separately from the legacy CRM/Park
+Telegram bot path.
+
+## Non-Execution Statement
+
+This file is a plan only.
+
+During creation of this plan:
+
+- No CRM task is created.
+- No Telegram message is sent.
+- No production DB migration is applied.
+- No deploy is performed.
+- No Railway setting is changed.
+- No webhook is activated.
+- No Hermes cron job is changed.
+
+## Required Approval String
+
+Do not execute this smoke unless the owner provides this exact approval block:
+
+```text
+APPROVE CRM HERMES OUTBOX E2E SMOKE
+CREATE_ONE_TEST_TASK=true
+TITLE="[HERMES_SMOKE] Тест outbox Hermes DM"
+OWNER_USER_ID=4
+SKIP_LEGACY_NOTIFICATIONS=true
+ALLOW_HERMES_SEND=true
+MAX_TELEGRAM_MESSAGES=1
+NO_DEPLOY=true
+NO_CRON_CHANGE=true
+NO_REAL_CLIENT_TASKS=true
+```
+
+Any missing or changed line means approval is incomplete.
+
+## Preconditions
+
+- Target CRM environment is explicitly named.
+- Target environment is not production unless the owner explicitly says it is
+  production and approves production execution.
+- CRM code includes `notification_outbox` schema and Hermes outbox endpoints.
+- CRM env/config enables outbox event creation for the target environment.
+- Hermes API auth is configured, but secrets are not printed in chat, logs, or
+  docs.
+- Test owner is `owner_user_id=4`.
+- The task title is exactly `[HERMES_SMOKE] Тест outbox Hermes DM`.
+- V0.6 Hermes polling fallback remains unchanged.
+- No real client task is selected or mutated.
+
+## Create Path
+
+Preferred create path after approval:
+
+```js
+services/kleshnya.createTask(payload, {
+  skipNotifications: true,
+  hermesOutboxEnabled: true,
+  hermesOutboxContext: { crmBaseUrl: "<approved CRM base URL>" }
+});
+```
+
+Use `skipNotifications: true` to avoid intentional legacy CRM/Park bot
+notification. The smoke is for Hermes-native delivery only.
+
+Do not blindly use:
+
+```http
+POST /api/hermes/tasks
+```
+
+That route is a Hermes task mutation path and can exercise behavior unrelated to
+this smoke. The smoke should create one real CRM task row while suppressing the
+legacy app-bot notification path.
+
+## Future Smoke Steps After Approval
+
+1. Confirm the approval block exactly matches the required approval string.
+2. Confirm the target CRM environment and base URL.
+3. Confirm no deploy, no cron change, and no real client task are involved.
+4. Create one test task with:
+   - title: `[HERMES_SMOKE] Тест outbox Hermes DM`
+   - `owner_user_id=4`
+   - `skipNotifications=true`
+5. Verify the CRM task id.
+6. Verify exactly one outbox event was created.
+7. Verify the event fields:
+   - `event_type=task_created`
+   - `status=pending`
+   - `task_id=<created task id>`
+   - `owner_user_id=4`
+8. Run the Hermes outbox worker in dry-run/render mode.
+9. Verify dry-run selects exactly one event.
+10. Run Hermes send once with explicit send flags.
+11. Verify exactly one Telegram message was sent.
+12. Capture the Telegram message id.
+13. Ack the outbox event in CRM.
+14. Verify `status=sent`.
+15. Re-run dry-run.
+16. Verify no duplicate candidate is selected.
+17. Do not complete, delete, archive, or mutate the test task unless separately
+    approved.
+
+## Suggested Safe Inspection Commands
+
+Use the API where possible:
+
+```http
+GET /api/hermes/notification-outbox?status=pending&limit=50
+GET /api/hermes/notification-outbox/stats
+GET /api/hermes/notification-outbox/debug?limit=20
+```
+
+If direct DB read access is explicitly approved for a non-production
+environment, keep it bounded and sanitized:
+
+```sql
+SELECT event_id, task_id, owner_user_id, event_type, status, attempts,
+       created_at, available_at, claimed_at, sent_at,
+       last_error_code, last_delivery_channel, last_delivery_target
+FROM notification_outbox
+WHERE task_id = <created_task_id>
+ORDER BY id DESC
+LIMIT 5;
+```
+
+Do not select full `payload_json` by default.
+
+## Expected Receipt After Future Execution
+
+The future executor should return this receipt shape:
+
+```text
+crm_task_created=true
+task_id=<id>
+skipNotifications=true
+legacyParkNotifyAttempted=false
+outbox_event_created=true
+event_id=<event_id>
+hermes_send_attempted=true
+telegram_message_id=<id>
+outbox_ack_status=sent
+post_run_duplicate_check=pass
+```
+
+If any line cannot be truthfully filled, report the blocker and stop.
+
+## Abort Conditions
+
+Stop immediately if:
+
+- More than one candidate event is selected.
+- More than one Telegram message would be sent.
+- The event is not `pending` before claim.
+- The owner id is not `4`.
+- The task title does not exactly match the smoke title.
+- Legacy CRM/Park bot notification is attempted.
+- Any secret would need to be printed.
+- The target appears to contain a real client task.
+- A deploy, cron change, webhook activation, or production migration is needed.
+
+## Rollback After Future Smoke
+
+Do not delete or complete the test task unless separately approved.
+
+If the smoke exposes a problem:
+
+1. Disable CRM outbox event creation with
+   `HERMES_NOTIFICATION_OUTBOX_ENABLED=false`,
+   `HERMES_TASK_OUTBOX_ENABLED=false`, or `NOTIFICATION_OUTBOX_ENABLED=false`.
+2. Keep the `notification_outbox` table for diagnostics.
+3. Keep the V0.6 Hermes polling cron as fallback.
+4. Do not change Hermes cron without explicit owner approval.
+5. Preserve sanitized evidence: task id, event id, status, attempts, and
+   `last_error_code`.
+
+## Fresh Codex Session Prompt
+
+Use this when starting a fresh Codex session:
+
+```text
+You are working in the Event Genix CRM repository.
+
+Goal:
+Implement CRM-side notification_outbox foundation for Hermes-native task notifications.
+
+Do not send Telegram, do not deploy, do not apply production migrations, do not change Hermes cron jobs, and do not print secrets.
+
+Current temporary fallback:
+Hermes V0.6 polling cron job_id=74d7a31ef2ab reads /api/hermes/tasks and /api/hermes/my-cabinet every 5 minutes and sends Telegram DMs via Hermes for approved owner routes:
+- Сергій ownerUserId=4 -> telegram:674972415
+- Наталія ownerUserId=3 -> telegram:606680445
+
+Do not disable or modify this fallback from the CRM repo.
+
+Final architecture:
+CRM Task Service -> notification_outbox -> Hermes Delivery Worker -> Telegram DM.
+Outbox is source of truth. Webhook is only accelerator.
+CRM legacy Telegram bot is not Hermes-native delivery.
+
+Execute only the task I name. Start with TASK 1 read-only discovery unless I explicitly ask for another task.
+After each task return:
+STATUS / FILES_CHANGED / TESTS_RUN / TEST_RESULT / SECURITY_NOTES / ROLLBACK_NOTES / BLOCKERS / NEXT_STEP.
+```

--- a/docs/hermes-notification-outbox.md
+++ b/docs/hermes-notification-outbox.md
@@ -1,0 +1,369 @@
+# Event Genix Hermes notification_outbox Runbook
+
+This runbook documents the CRM-side outbox used for Hermes task direct-message
+delivery. It is for developers and operators working on Event Genix CRM and
+Hermes delivery workers.
+
+## 1. Purpose
+
+`notification_outbox` is the durable CRM-side source of truth for task
+notification events that Hermes should deliver as Telegram direct messages.
+
+The intended flow is:
+
+```text
+CRM Task Service
+  -> CRM notification_outbox
+  -> Hermes Delivery Worker
+  -> Telegram DM through Hermes/main-agent
+```
+
+The outbox exists so CRM task creation does not depend on immediate Telegram
+delivery. CRM records the event first, Hermes claims and delivers it, then
+Hermes acknowledges or fails the event through the CRM API.
+
+## 2. Architecture
+
+```mermaid
+flowchart LR
+    A["Task created"] --> B["notification_outbox pending"]
+    B --> C["Hermes claim"]
+    C --> D["Telegram send via Hermes"]
+    D --> E["ack sent"]
+    D --> F["fail retry"]
+    F --> B
+    F --> G["dead_letter"]
+```
+
+Rules:
+
+- `notification_outbox` is the source of truth.
+- Webhooks, if added later, are accelerators only.
+- CRM legacy Telegram bot delivery is not the Hermes-native task DM channel.
+- Hermes delivery must not be implemented by calling `services/telegram.js`
+  from the CRM outbox path.
+
+## 3. Current V0.6 Fallback
+
+The temporary V0.6 fallback is a Hermes-side polling worker:
+
+- Job id: `74d7a31ef2ab`
+- Name: `Event Genix Hermes Task DM - all approved owners`
+- Script: `event_genix_hermes_task_dm_all_owners_cron.py`
+- Schedule: every 5 minutes
+
+It reads CRM read-only endpoints:
+
+- `GET /api/hermes/tasks?ownerUserId=<id>&limit=50`
+- `GET /api/hermes/my-cabinet?ownerUserId=<id>`
+
+Approved owners in the fallback:
+
+- Sergiy: `ownerUserId=4`
+- Nataliia: `ownerUserId=3`
+
+Do not change Hermes cron jobs from the CRM repo without explicit owner
+approval. Keep V0.6 polling available as the incident fallback until the
+Hermes delivery worker has been approved and proven in production.
+
+## 4. notification_outbox Table Fields
+
+Migration: `db/migrations/273_notification_outbox.sql`
+
+Important fields:
+
+| Field | Purpose |
+| --- | --- |
+| `id` | Internal primary key and cursor source. |
+| `event_id` | Unique deterministic event identity. |
+| `task_id` | CRM task reference. |
+| `owner_user_id` | CRM responsible user id. |
+| `event_type` | Event type such as `task_created`. |
+| `payload_json` | Sanitized delivery payload for Hermes. |
+| `payload_hash` | Stable hash for idempotency and duplicate protection. |
+| `status` | Lifecycle status. |
+| `attempts` | Delivery failure attempt count. |
+| `available_at` | Earliest time the event may be listed/claimed. |
+| `created_at` | Row creation time. |
+| `claimed_at` | Last claim time. |
+| `sent_at` | Delivery acknowledgment time. |
+| `last_error` | Sanitized last failure message. |
+| `last_error_code` | Machine-readable last failure code. |
+| `last_delivery_channel` | Last delivery channel, for example `telegram`. |
+| `last_delivery_target` | Last delivery target id. |
+| `claimed_by` | Worker id that claimed the event. |
+| `locked_until` | Claim lock expiry. |
+| `updated_at` | Last row update time. |
+
+Allowed statuses:
+
+- `pending`
+- `claimed`
+- `sent`
+- `failed`
+- `dead_letter`
+- `skipped`
+
+Initial active event types:
+
+- `task_created`
+- `task_assigned`
+
+Reserved future event types:
+
+- `task_reminder_due`
+- `task_overdue`
+- `task_updated`
+
+## 5. Event Lifecycle
+
+1. `createTask()` creates the CRM task.
+2. If the task has an owner and is active, CRM inserts one `pending` outbox
+   event.
+3. Hermes reads available events from `/api/hermes/notification-outbox`.
+4. Hermes claims one event with `/claim`, setting `status=claimed`,
+   `claimed_by`, `claimed_at`, and `locked_until`.
+5. Hermes sends the Telegram DM through Hermes/main-agent.
+6. Hermes calls `/ack` after delivery, setting `status=sent`.
+7. If delivery fails, Hermes calls `/fail`.
+8. Retryable failures move the event to `failed` with a future
+   `available_at`.
+9. Exhausted or non-retryable failures move to `dead_letter`.
+
+Task creation does not send Telegram directly through the outbox path.
+
+## 6. Hermes API Endpoints
+
+All endpoints are under `/api/hermes` and use the existing Hermes auth.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/notification-outbox?status=pending&limit=50` | List available events. |
+| `GET` | `/notification-outbox/:eventId` | Read one sanitized event. |
+| `POST` | `/notification-outbox/:eventId/claim` | Claim an event for a worker. |
+| `POST` | `/notification-outbox/:eventId/ack` | Mark delivery as sent. |
+| `POST` | `/notification-outbox/:eventId/fail` | Record delivery failure. |
+| `GET` | `/notification-outbox/stats` | Read safe aggregate queue diagnostics. |
+| `GET` | `/notification-outbox/debug?limit=20` | Read safe diagnostic event rows. |
+
+List query parameters:
+
+- `status`: one of the allowed statuses, default `pending`
+- `limit`: default `20`, max `50`
+- `cursor`: numeric cursor
+- `ownerUserId`: optional owner filter
+- `eventType`: optional event type filter
+
+Claim body:
+
+```json
+{
+  "workerId": "hermes-worker-1",
+  "lockSeconds": 120
+}
+```
+
+Ack body:
+
+```json
+{
+  "workerId": "hermes-worker-1",
+  "channel": "telegram",
+  "target": "674972415",
+  "deliveryId": "optional-provider-id",
+  "messageHash": "optional-message-hash",
+  "sentAt": "2026-06-29T12:03:00.000Z"
+}
+```
+
+Fail body:
+
+```json
+{
+  "workerId": "hermes-worker-1",
+  "errorCode": "TELEGRAM_RATE_LIMIT",
+  "errorMessage": "rate limited",
+  "retryable": true
+}
+```
+
+## 7. Retry And dead_letter Policy
+
+Retryable `/fail` responses increment `attempts` and move `available_at`
+forward:
+
+| Attempt | Delay |
+| --- | --- |
+| 1 | 1 minute |
+| 2 | 5 minutes |
+| 3 | 30 minutes |
+| 4 | 2 hours |
+| 5 | `dead_letter` |
+
+Non-retryable failures move directly to `dead_letter`.
+
+`/ack` is idempotent for already sent events. A second ack returns success and
+does not corrupt the sent status.
+
+## 8. Security And Auth
+
+Preferred auth header:
+
+```http
+x-api-key: <Hermes CRM API key>
+```
+
+Allowed fallback:
+
+```http
+Authorization: Bearer <Hermes CRM API key>
+```
+
+Do not document, print, commit, or paste real API keys, bot tokens, cookies,
+raw headers, or production payload dumps.
+
+Outbox payloads and debug responses must stay sanitized. By default,
+diagnostic endpoints do not return full `payload_json`, raw private client
+details, stack traces, secrets, or raw provider responses.
+
+## 9. Feature Flags
+
+Current CRM code supports outbox event creation flags:
+
+- `HERMES_TASK_OUTBOX_ENABLED=true|false`
+- `HERMES_NOTIFICATION_OUTBOX_ENABLED=true|false`
+- `NOTIFICATION_OUTBOX_ENABLED=true|false`
+
+If neither flag is set, outbox creation defaults on only in local/test-like
+runtime modes and remains conservative elsewhere.
+
+Preferred operational flag:
+
+- `HERMES_NOTIFICATION_OUTBOX_ENABLED=true|false`
+
+Compatibility flags remain supported for existing environments. Explicit flag
+values override default runtime behavior.
+
+## 10. How To Test Locally
+
+Use the repository Node baseline:
+
+```powershell
+npm run check:runtime
+```
+
+If the local shell is not Node 22/npm 10, use:
+
+```powershell
+npx -y -p node@22 -p npm@10 -c "npm run check:runtime"
+```
+
+Focused outbox tests:
+
+```powershell
+npx -y -p node@22 -p npm@10 -c "node --test tests/notification-outbox.test.js tests/kleshnya-notification-outbox.test.js tests/hermes-notification-outbox.test.js tests/notification-outbox-lifecycle.test.js"
+```
+
+Full unit baseline:
+
+```powershell
+npx -y -p node@22 -p npm@10 -c "npm run test:unit"
+```
+
+Static checks:
+
+```powershell
+npx -y -p node@22 -p npm@10 -c "npm run check:syntax"
+npx -y -p node@22 -p npm@10 -c "npm run check:api-surface"
+npx -y -p node@22 -p npm@10 -c "npm run check:migrations"
+```
+
+Do not run live Telegram sends as a local test.
+
+## 11. How To Inspect Stuck Events
+
+Preferred safe API:
+
+```http
+GET /api/hermes/notification-outbox/stats
+GET /api/hermes/notification-outbox/debug?limit=20
+```
+
+Use stats to check queue depth:
+
+- `pending`: waiting to be claimed
+- `claimed`: currently locked by a worker
+- `failed`: retryable failures waiting for `available_at`
+- `dead_letter`: exhausted or non-retryable failures
+- `skipped`: intentionally skipped events
+- `sent_24h`: recent successful deliveries
+
+Use debug to inspect safe row metadata:
+
+- `event_id`
+- `task_id`
+- `owner_user_id`
+- `event_type`
+- `status`
+- `attempts`
+- `created_at`
+- `available_at`
+- `last_error_code`
+
+If direct DB inspection is approved for a non-production environment, use
+bounded, sanitized reads only. Example:
+
+```sql
+SELECT event_id, task_id, owner_user_id, event_type, status, attempts,
+       created_at, available_at, locked_until, claimed_by, last_error_code
+FROM notification_outbox
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+Do not select `payload_json` by default during incident triage.
+
+## 12. Rollback Plan
+
+If CRM outbox feature causes issues:
+
+- Disable event creation with feature flag/config.
+- Keep table for diagnostics.
+- Keep V0.6 Hermes polling cron as fallback.
+- Do not drop `notification_outbox` table during incident.
+- Do not change Hermes cron without explicit owner approval.
+
+Operational rollback sequence:
+
+1. Set `HERMES_NOTIFICATION_OUTBOX_ENABLED=false`,
+   `HERMES_TASK_OUTBOX_ENABLED=false`, or `NOTIFICATION_OUTBOX_ENABLED=false`
+   in the affected CRM environment.
+2. Restart only after normal environment-change approval.
+3. Confirm `/api/hermes/notification-outbox/stats` still works for diagnostics.
+4. Leave existing outbox rows intact for post-incident analysis.
+5. Continue using the V0.6 Hermes polling cron until the owner approves a new
+   delivery-worker activation plan.
+
+Schema rollback is not the incident path. Dropping the table removes evidence
+and may break diagnostics.
+
+## 13. E2E Smoke Approval Gate
+
+Any end-to-end smoke that can send a real Telegram DM, mutate production data,
+change Railway, activate a webhook, or change Hermes cron jobs requires explicit
+owner approval before execution.
+
+Approval-gated smoke checklist:
+
+1. Confirm target environment and CRM base URL.
+2. Confirm Hermes API credentials are configured without printing them.
+3. Confirm approved test owner/user and Telegram target.
+4. Create or select a non-client test task.
+5. Confirm one `pending` outbox row appears.
+6. Run Hermes claim/send/ack path.
+7. Confirm status moves to `sent`.
+8. Confirm no legacy CRM/Park bot path was used for Hermes-native delivery.
+9. Record sanitized results only.
+
+Do not execute this checklist against production or live Telegram without
+explicit approval.

--- a/routes/hermes.js
+++ b/routes/hermes.js
@@ -1,0 +1,157 @@
+/**
+ * routes/hermes.js — minimal Hermes worker API for notification_outbox.
+ * Clean-branch compatibility route: exposes only notification_outbox endpoints.
+ */
+const router = require('express').Router();
+const { pool } = require('../db');
+const { createLogger } = require('../utils/logger');
+const {
+    ackNotificationOutboxEvent,
+    claimNotificationOutboxEvent,
+    failNotificationOutboxEvent,
+    findNotificationOutboxEventByEventId,
+    getNotificationOutboxStats,
+    listNotificationOutboxDebugEvents,
+    listNotificationOutboxEvents,
+    toNotificationOutboxApiEvent
+} = require('../services/notificationOutbox');
+
+const log = createLogger('Hermes');
+const SUPPORTED_ACTIONS = [
+    'notification_outbox.read',
+    'notification_outbox.detail',
+    'notification_outbox.claim',
+    'notification_outbox.ack',
+    'notification_outbox.fail',
+    'notification_outbox.stats',
+    'notification_outbox.debug'
+];
+
+function extractBearer(req) {
+    const value = String(req.headers.authorization || '');
+    const match = value.match(/^Bearer\s+(.+)$/i);
+    return match ? match[1].trim() : '';
+}
+
+function hermesAuth(req, res, next) {
+    const configured = String(
+        process.env.HERMES_API_KEY ||
+        process.env.HERMES_SHARED_SECRET ||
+        process.env.HERMES_TOKEN ||
+        ''
+    ).trim();
+
+    if (!configured && process.env.NODE_ENV !== 'test') {
+        return res.status(503).json({
+            success: false,
+            code: 'HERMES_API_KEY_NOT_CONFIGURED',
+            error: 'Hermes API key is not configured'
+        });
+    }
+
+    if (configured) {
+        const supplied = String(req.get('x-hermes-api-key') || extractBearer(req) || '').trim();
+        if (supplied !== configured) {
+            return res.status(401).json({
+                success: false,
+                code: 'HERMES_UNAUTHORIZED',
+                error: 'Hermes API key is invalid or missing'
+            });
+        }
+    }
+
+    return next();
+}
+
+function sendHermesError(res, err, fallbackCode = 'HERMES_INTERNAL_ERROR', fallbackMessage = 'Hermes notification_outbox error') {
+    const status = Number(err?.statusCode || err?.status || 500);
+    const code = err?.code || fallbackCode;
+    const message = err?.message || fallbackMessage;
+    if (status >= 500) log.error(fallbackMessage, err);
+    return res.status(status).json({ success: false, code, error: message, meta: err?.meta || undefined });
+}
+
+router.use(hermesAuth);
+
+router.get('/capabilities', (req, res) => {
+    res.json({ success: true, integration: 'hermes', actions: SUPPORTED_ACTIONS });
+});
+
+router.get('/notification-outbox', async (req, res) => {
+    try {
+        const result = await listNotificationOutboxEvents({
+            status: req.query.status,
+            limit: req.query.limit,
+            cursor: req.query.cursor,
+            ownerUserId: req.query.ownerUserId || req.query.owner_user_id,
+            eventType: req.query.eventType || req.query.event_type
+        }, { pool });
+        res.json({
+            success: true,
+            events: result.events.map(toNotificationOutboxApiEvent).filter(Boolean),
+            pagination: result.pagination
+        });
+    } catch (err) {
+        sendHermesError(res, err, 'OUTBOX_LIST_FAILED', 'Failed to list notification_outbox events');
+    }
+});
+
+router.get('/notification-outbox/stats', async (req, res) => {
+    try {
+        const result = await getNotificationOutboxStats({ pool });
+        res.json({ success: true, ...result });
+    } catch (err) {
+        sendHermesError(res, err, 'OUTBOX_STATS_FAILED', 'Failed to read notification_outbox stats');
+    }
+});
+
+router.get('/notification-outbox/debug', async (req, res) => {
+    try {
+        const result = await listNotificationOutboxDebugEvents({
+            status: req.query.status,
+            limit: req.query.limit
+        }, { pool });
+        res.json({ success: true, ...result });
+    } catch (err) {
+        sendHermesError(res, err, 'OUTBOX_DEBUG_FAILED', 'Failed to read notification_outbox debug data');
+    }
+});
+
+router.get('/notification-outbox/:eventId', async (req, res) => {
+    try {
+        const event = await findNotificationOutboxEventByEventId(req.params.eventId, { pool });
+        if (!event) return res.status(404).json({ success: false, code: 'OUTBOX_EVENT_NOT_FOUND', error: 'notification_outbox event was not found' });
+        res.json({ success: true, event: toNotificationOutboxApiEvent(event) });
+    } catch (err) {
+        sendHermesError(res, err, 'OUTBOX_DETAIL_FAILED', 'Failed to read notification_outbox event');
+    }
+});
+
+router.post('/notification-outbox/:eventId/claim', async (req, res) => {
+    try {
+        const result = await claimNotificationOutboxEvent(req.params.eventId, req.body || {}, { pool });
+        res.json({ success: true, ...result, event: toNotificationOutboxApiEvent(result.event) });
+    } catch (err) {
+        sendHermesError(res, err, 'OUTBOX_CLAIM_FAILED', 'Failed to claim notification_outbox event');
+    }
+});
+
+router.post('/notification-outbox/:eventId/ack', async (req, res) => {
+    try {
+        const result = await ackNotificationOutboxEvent(req.params.eventId, req.body || {}, { pool });
+        res.json({ success: true, ...result, event: toNotificationOutboxApiEvent(result.event) });
+    } catch (err) {
+        sendHermesError(res, err, 'OUTBOX_ACK_FAILED', 'Failed to ack notification_outbox event');
+    }
+});
+
+router.post('/notification-outbox/:eventId/fail', async (req, res) => {
+    try {
+        const result = await failNotificationOutboxEvent(req.params.eventId, req.body || {}, { pool });
+        res.json({ success: true, ...result, event: toNotificationOutboxApiEvent(result.event) });
+    } catch (err) {
+        sendHermesError(res, err, 'OUTBOX_FAIL_FAILED', 'Failed to fail notification_outbox event');
+    }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -95,7 +95,7 @@ app.use('/api', rateLimiter);
 
 // Auth middleware: protect all API endpoints except public ones
 app.use('/api', (req, res, next) => {
-    if (req.path.startsWith('/auth/') || req.path === '/health' || req.path === '/version' || req.path.startsWith('/telegram/webhook') || req.path === '/kleshnya/webhook' || req.path === '/kleshnya/pending-messages' || req.path === '/kleshnya/sync-chat' || req.path === '/demo/login' || req.path === '/demo/scenarios' || req.path === '/packages' || req.path === '/status/public' || req.path.startsWith('/leads/webhook/') || (req.path === '/leads/landing' && req.method === 'POST')) {
+    if (req.path.startsWith('/auth/') || req.path === '/health' || req.path === '/version' || req.path === '/hermes/capabilities' || req.path.startsWith('/hermes/notification-outbox') || req.path.startsWith('/telegram/webhook') || req.path === '/kleshnya/webhook' || req.path === '/kleshnya/pending-messages' || req.path === '/kleshnya/sync-chat' || req.path === '/demo/login' || req.path === '/demo/scenarios' || req.path === '/packages' || req.path === '/status/public' || req.path.startsWith('/leads/webhook/') || (req.path === '/leads/landing' && req.method === 'POST')) {
         return next();
     }
     authenticateToken(req, res, next);
@@ -123,6 +123,7 @@ app.use('/api/backup/restore', express.json({ limit: '50mb' }));
 app.use('/api/backup', require('./routes/backup'));
 app.use('/api/products', require('./routes/products'));
 app.use('/api/tasks', require('./routes/tasks'));
+app.use('/api/hermes', require('./routes/hermes'));
 app.use('/api/task-templates', require('./routes/task-templates'));
 app.use('/api/staff', require('./routes/staff'));
 app.use('/api/certificates', require('./routes/certificates'));

--- a/services/kleshnya.js
+++ b/services/kleshnya.js
@@ -16,6 +16,7 @@
 const { pool } = require('../db');
 const { sendTelegramMessage, getConfiguredChatId, getConfiguredThreadId, telegramRequest } = require('./telegram');
 const { createLogger } = require('../utils/logger');
+const { emitTaskCreatedNotificationOutboxEvent } = require('./notificationOutbox');
 
 const log = createLogger('Kleshnya');
 
@@ -61,13 +62,15 @@ function getCurrentMonth() {
 /**
  * Create a task through Kleshnya (with logging + notification)
  */
-async function createTask(data) {
+async function createTask(data, options = {}) {
     const {
         title, description, date, priority = 'normal', assigned_to, owner,
         task_type = 'human', deadline, time_window_start, time_window_end,
         dependency_ids = [], control_policy, source_type = 'manual', source_id,
         category = 'admin', template_id, afisha_id, created_by = 'kleshnya'
     } = data;
+
+    const ownerUserId = Number(data.owner_user_id || data.ownerUserId || options.owner_user_id || options.ownerUserId || 0);
 
     if (!title || !title.trim()) throw new Error('title required');
 
@@ -88,6 +91,16 @@ async function createTask(data) {
 
     // Log creation
     await logTaskAction(task.id, 'created', null, title, created_by);
+
+    await emitTaskCreatedNotificationOutboxEvent({
+        ...task,
+        owner_user_id: Number.isInteger(ownerUserId) && ownerUserId > 0 ? ownerUserId : task.owner_user_id
+    }, {
+        skipHermesOutbox: options.skipHermesOutbox,
+        hermesOutboxEnabled: options.hermesOutboxEnabled,
+        hermesOutboxContext: options.hermesOutboxContext || options.notificationContext || {},
+        env: options.env
+    }).catch(err => log.error(`Hermes notification_outbox error: ${err.message}`));
 
     // Notify assigned person (fire-and-forget — never block task creation)
     if (assigned_to && task_type === 'human') {

--- a/services/notificationOutbox.js
+++ b/services/notificationOutbox.js
@@ -1,0 +1,886 @@
+'use strict';
+
+const crypto = require('crypto');
+const { pool: defaultPool } = require('../db');
+
+const NOTIFICATION_OUTBOX_STATUSES = Object.freeze([
+    'pending',
+    'claimed',
+    'sent',
+    'failed',
+    'dead_letter',
+    'skipped'
+]);
+
+const INITIAL_TASK_NOTIFICATION_EVENT_TYPES = Object.freeze([
+    'task_created',
+    'task_assigned'
+]);
+
+const FUTURE_TASK_NOTIFICATION_EVENT_TYPES = Object.freeze([
+    'task_reminder_due',
+    'task_overdue',
+    'task_updated'
+]);
+
+const TASK_NOTIFICATION_EVENT_TYPES = Object.freeze([
+    ...INITIAL_TASK_NOTIFICATION_EVENT_TYPES,
+    ...FUTURE_TASK_NOTIFICATION_EVENT_TYPES
+]);
+
+const TASK_NOTIFICATION_EVENT_TYPE_SET = new Set(TASK_NOTIFICATION_EVENT_TYPES);
+const NOTIFICATION_OUTBOX_STATUS_SET = new Set(NOTIFICATION_OUTBOX_STATUSES);
+
+const DEFAULT_NOTIFICATION_OUTBOX_LIMIT = 20;
+const MAX_NOTIFICATION_OUTBOX_LIMIT = 50;
+const DEFAULT_NOTIFICATION_OUTBOX_LOCK_SECONDS = 120;
+const MAX_NOTIFICATION_OUTBOX_LOCK_SECONDS = 3600;
+const DEAD_LETTER_ATTEMPT_THRESHOLD = 5;
+
+const NOTIFICATION_OUTBOX_RETRY_BACKOFF_MINUTES = Object.freeze({
+    1: 1,
+    2: 5,
+    3: 30,
+    4: 120
+});
+
+const SAFE_TASK_PAYLOAD_FIELDS = Object.freeze([
+    'taskId',
+    'title',
+    'status',
+    'priority',
+    'ownerUserId',
+    'ownerLabel',
+    'dueAt',
+    'crmUrl',
+    'createdAt',
+    'updatedAt'
+]);
+
+const STATUS_MAP = Object.freeze({
+    todo: 'open',
+    in_progress: 'in_progress',
+    done: 'done',
+    archived: 'archived',
+    cancelled: 'cancelled',
+    canceled: 'cancelled'
+});
+
+const PRIORITIES = new Set(['critical', 'urgent', 'high', 'normal', 'low']);
+
+function positiveIntegerOrNull(value) {
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function envFlag(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+    return null;
+}
+
+function firstEnvFlag(...values) {
+    for (const value of values) {
+        const parsed = envFlag(value);
+        if (parsed !== null) return parsed;
+    }
+    return null;
+}
+
+function firstPresent(source = {}, keys = []) {
+    for (const key of keys) {
+        const value = source[key];
+        if (value !== undefined && value !== null && value !== '') return value;
+    }
+    return null;
+}
+
+function textOrNull(value) {
+    if (value === undefined || value === null) return null;
+    const text = String(value).trim();
+    return text || null;
+}
+
+function safeTextOrNull(value, maxLength = 500) {
+    const text = textOrNull(value);
+    if (!text) return null;
+    return text
+        .replace(/[\u0000-\u001F\u007F]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, maxLength);
+}
+
+function isoOrNull(value) {
+    if (!value) return null;
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString();
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function compactObject(input = {}) {
+    return Object.fromEntries(
+        Object.entries(input).filter(([, value]) => value !== undefined && value !== null)
+    );
+}
+
+function normalizeTaskId(task = {}) {
+    return positiveIntegerOrNull(firstPresent(task, ['taskId', 'task_id', 'id']));
+}
+
+function normalizeOwnerUserId(task = {}) {
+    return positiveIntegerOrNull(firstPresent(task, ['ownerUserId', 'owner_user_id']));
+}
+
+function normalizeEventType(eventType) {
+    const normalized = String(eventType || '').trim();
+    return TASK_NOTIFICATION_EVENT_TYPE_SET.has(normalized) ? normalized : null;
+}
+
+function normalizeOutboxStatus(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+    return NOTIFICATION_OUTBOX_STATUS_SET.has(normalized) ? normalized : null;
+}
+
+function hermesTaskOutboxEnabled(options = {}, env = process.env) {
+    if (typeof options.hermesOutboxEnabled === 'boolean') return options.hermesOutboxEnabled;
+
+    const explicit = firstEnvFlag(
+        env.HERMES_TASK_OUTBOX_ENABLED,
+        env.HERMES_NOTIFICATION_OUTBOX_ENABLED,
+        env.NOTIFICATION_OUTBOX_ENABLED
+    );
+    if (explicit !== null) return explicit;
+
+    const nodeEnv = String(env.NODE_ENV || '').trim().toLowerCase();
+    return ['test', 'development', 'local'].includes(nodeEnv);
+}
+
+function isActiveTaskForHermesOutbox(task = {}) {
+    if (task.is_active === false || task.deleted_at || task.archived_at) return false;
+    const status = String(task.status || task.workflow_state || 'todo').trim().toLowerCase();
+    return !['done', 'completed', 'archived', 'cancelled', 'canceled', 'deleted'].includes(status);
+}
+
+function notificationOutboxHttpError(statusCode, code, message, meta = null) {
+    const err = new Error(message);
+    err.statusCode = statusCode;
+    err.code = code;
+    if (meta && typeof meta === 'object') err.meta = meta;
+    return err;
+}
+
+function requireTaskNotificationIdentity(task = {}, eventType) {
+    const taskId = normalizeTaskId(task);
+    if (!taskId) {
+        const err = new Error('Valid task_id is required for notification_outbox');
+        err.code = 'NOTIFICATION_OUTBOX_TASK_ID_REQUIRED';
+        throw err;
+    }
+
+    const ownerUserId = normalizeOwnerUserId(task);
+    if (!ownerUserId) {
+        const err = new Error('Valid owner_user_id is required for notification_outbox');
+        err.code = 'NOTIFICATION_OUTBOX_OWNER_USER_ID_REQUIRED';
+        throw err;
+    }
+
+    const type = normalizeEventType(eventType);
+    if (!type) {
+        const err = new Error('Valid event_type is required for notification_outbox');
+        err.code = 'NOTIFICATION_OUTBOX_EVENT_TYPE_INVALID';
+        throw err;
+    }
+
+    return { taskId, ownerUserId, eventType: type };
+}
+
+function normalizeStatus(value) {
+    const raw = String(value || 'todo').trim().toLowerCase();
+    return STATUS_MAP[raw] || 'open';
+}
+
+function normalizePriority(value) {
+    const raw = String(value || 'normal').trim().toLowerCase();
+    if (raw === 'medium') return 'normal';
+    return PRIORITIES.has(raw) ? raw : 'normal';
+}
+
+function taskCrmUrl(taskId, context = {}) {
+    const explicit = textOrNull(context.crmUrl || context.taskUrl);
+    if (explicit) return explicit;
+
+    const baseUrl = textOrNull(
+        context.crmBaseUrl
+        || context.baseUrl
+        || context.publicBaseUrl
+        || process.env.PUBLIC_BASE_URL
+        || process.env.APP_BASE_URL
+    );
+    const path = `/tasks?open=${encodeURIComponent(taskId)}`;
+    return baseUrl ? `${baseUrl.replace(/\/+$/, '')}${path}` : path;
+}
+
+function taskDueAt(task = {}) {
+    return isoOrNull(firstPresent(task, [
+        'dueAt',
+        'due_at',
+        'scheduledStartAt',
+        'scheduled_start_at',
+        'deadline',
+        'date'
+    ]));
+}
+
+function ownerLabel(task = {}) {
+    return textOrNull(firstPresent(task, [
+        'ownerLabel',
+        'owner_label',
+        'owner_name',
+        'ownerName',
+        'owner_username',
+        'ownerUsername',
+        'assigned_to',
+        'assignedTo',
+        'owner'
+    ]));
+}
+
+function buildTaskNotificationPayload(task = {}, context = {}) {
+    const { taskId, ownerUserId } = requireTaskNotificationIdentity(
+        task,
+        context.eventType || context.event_type || 'task_created'
+    );
+
+    return compactObject({
+        taskId,
+        title: textOrNull(task.title) || `Task #${taskId}`,
+        status: normalizeStatus(task.status),
+        priority: normalizePriority(task.priority),
+        ownerUserId,
+        ownerLabel: ownerLabel(task),
+        dueAt: taskDueAt(task),
+        crmUrl: taskCrmUrl(taskId, context),
+        createdAt: isoOrNull(firstPresent(task, ['createdAt', 'created_at'])),
+        updatedAt: isoOrNull(firstPresent(task, ['updatedAt', 'updated_at', 'createdAt', 'created_at']))
+    });
+}
+
+function stableValue(value) {
+    if (value === undefined) return null;
+    if (value === null) return null;
+    if (value instanceof Date) return value.toISOString();
+    if (Array.isArray(value)) return value.map(stableValue);
+    if (typeof value !== 'object') return value;
+
+    const output = {};
+    for (const key of Object.keys(value).sort()) {
+        output[key] = stableValue(value[key]);
+    }
+    return output;
+}
+
+function stableJsonStringify(value) {
+    return JSON.stringify(stableValue(value));
+}
+
+function hashNotificationPayload(payload) {
+    return crypto
+        .createHash('sha256')
+        .update(stableJsonStringify(payload))
+        .digest('hex');
+}
+
+function generateNotificationEventId(task = {}, eventType) {
+    const identity = requireTaskNotificationIdentity(task, eventType);
+    return `${identity.eventType}:${identity.taskId}:owner:${identity.ownerUserId}`;
+}
+
+function normalizeOutboxRow(row = null) {
+    if (!row) return null;
+    let payloadJson = row.payload_json;
+    if (typeof payloadJson === 'string') {
+        try {
+            payloadJson = JSON.parse(payloadJson);
+        } catch {
+            payloadJson = {};
+        }
+    }
+    return {
+        ...row,
+        payload_json: payloadJson && typeof payloadJson === 'object' && !Array.isArray(payloadJson)
+            ? payloadJson
+            : {}
+    };
+}
+
+function sanitizeTaskNotificationPayload(payload = {}) {
+    const source = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {};
+    const sanitized = {};
+    for (const key of SAFE_TASK_PAYLOAD_FIELDS) {
+        if (source[key] !== undefined && source[key] !== null) {
+            sanitized[key] = source[key];
+        }
+    }
+    return sanitized;
+}
+
+function toNotificationOutboxApiEvent(row = null) {
+    const normalized = normalizeOutboxRow(row);
+    if (!normalized) return null;
+
+    return compactObject({
+        eventId: normalized.event_id,
+        taskId: normalized.task_id === undefined || normalized.task_id === null ? null : Number(normalized.task_id),
+        ownerUserId: normalized.owner_user_id === undefined || normalized.owner_user_id === null ? null : Number(normalized.owner_user_id),
+        eventType: normalized.event_type,
+        payload: sanitizeTaskNotificationPayload(normalized.payload_json),
+        payloadHash: normalized.payload_hash || null,
+        status: normalized.status,
+        attempts: Number(normalized.attempts || 0),
+        availableAt: isoOrNull(normalized.available_at),
+        createdAt: isoOrNull(normalized.created_at),
+        updatedAt: isoOrNull(normalized.updated_at),
+        claimedAt: isoOrNull(normalized.claimed_at),
+        sentAt: isoOrNull(normalized.sent_at),
+        claimedBy: safeTextOrNull(normalized.claimed_by, 120),
+        lockedUntil: isoOrNull(normalized.locked_until),
+        lastError: safeTextOrNull(normalized.last_error, 500),
+        lastErrorCode: safeTextOrNull(normalized.last_error_code, 120),
+        lastDeliveryChannel: safeTextOrNull(normalized.last_delivery_channel, 80),
+        lastDeliveryTarget: safeTextOrNull(normalized.last_delivery_target, 200)
+    });
+}
+
+function toNotificationOutboxDebugItem(row = null) {
+    if (!row) return null;
+    return {
+        event_id: safeTextOrNull(row.event_id, 240),
+        task_id: row.task_id === undefined || row.task_id === null ? null : Number(row.task_id),
+        owner_user_id: row.owner_user_id === undefined || row.owner_user_id === null ? null : Number(row.owner_user_id),
+        event_type: safeTextOrNull(row.event_type, 80),
+        status: safeTextOrNull(row.status, 40),
+        attempts: Number(row.attempts || 0),
+        created_at: isoOrNull(row.created_at),
+        available_at: isoOrNull(row.available_at),
+        last_error_code: safeTextOrNull(row.last_error_code, 120)
+    };
+}
+
+function normalizeNotificationOutboxLimit(value) {
+    if (value === undefined || value === null || value === '') return DEFAULT_NOTIFICATION_OUTBOX_LIMIT;
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_NOTIFICATION_OUTBOX_LIMIT;
+    return Math.min(parsed, MAX_NOTIFICATION_OUTBOX_LIMIT);
+}
+
+function normalizeCursor(value) {
+    if (value === undefined || value === null || value === '') return null;
+    const text = String(value).trim();
+    if (!/^\d+$/.test(text)) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_INVALID_CURSOR', 'cursor must be a positive integer cursor');
+    }
+    const parsed = Number.parseInt(text, 10);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_INVALID_CURSOR', 'cursor must be a positive integer cursor');
+    }
+    return parsed;
+}
+
+function pushSqlParam(params, value) {
+    params.push(value);
+    return `$${params.length}`;
+}
+
+function isFutureTimestamp(value) {
+    const iso = isoOrNull(value);
+    return iso ? new Date(iso).getTime() > Date.now() : false;
+}
+
+function requireWorkerId(value) {
+    const workerId = safeTextOrNull(value, 120);
+    if (!workerId) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_WORKER_ID_REQUIRED', 'workerId is required');
+    }
+    return workerId;
+}
+
+function normalizeLockSeconds(value) {
+    if (value === undefined || value === null || value === '') return DEFAULT_NOTIFICATION_OUTBOX_LOCK_SECONDS;
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_INVALID_LOCK_SECONDS', 'lockSeconds must be a positive integer');
+    }
+    return Math.min(parsed, MAX_NOTIFICATION_OUTBOX_LOCK_SECONDS);
+}
+
+function normalizeSentAt(value) {
+    if (value === undefined || value === null || value === '') return null;
+    const iso = isoOrNull(value);
+    if (!iso) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_INVALID_SENT_AT', 'sentAt must be a valid timestamp');
+    }
+    return iso;
+}
+
+function requireDeliveryChannel(value) {
+    const channel = safeTextOrNull(value, 80);
+    if (!channel) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_DELIVERY_CHANNEL_REQUIRED', 'channel is required');
+    }
+    return channel;
+}
+
+function requireDeliveryTarget(value) {
+    const target = safeTextOrNull(value, 200);
+    if (!target) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_DELIVERY_TARGET_REQUIRED', 'target is required');
+    }
+    return target;
+}
+
+function canWorkerMutateClaim(row, workerId) {
+    const claimedBy = safeTextOrNull(row?.claimed_by, 120);
+    return !claimedBy || !workerId || claimedBy === workerId;
+}
+
+function assertClaimedByWorker(row, workerId) {
+    if (row?.status !== 'claimed') {
+        throw notificationOutboxHttpError(409, 'OUTBOX_EVENT_NOT_CLAIMED', 'notification_outbox event is not claimed');
+    }
+    if (!canWorkerMutateClaim(row, workerId)) {
+        throw notificationOutboxHttpError(409, 'OUTBOX_EVENT_CLAIMED_BY_DIFFERENT_WORKER', 'notification_outbox event is claimed by another worker', {
+            claimedBy: safeTextOrNull(row.claimed_by, 120),
+            lockedUntil: isoOrNull(row.locked_until)
+        });
+    }
+}
+
+function throwClaimConflict(row) {
+    if (!row) {
+        throw notificationOutboxHttpError(404, 'OUTBOX_EVENT_NOT_FOUND', 'notification_outbox event was not found');
+    }
+    if (row.status === 'sent') {
+        throw notificationOutboxHttpError(409, 'OUTBOX_EVENT_ALREADY_SENT', 'notification_outbox event is already sent');
+    }
+    if (row.status === 'claimed') {
+        throw notificationOutboxHttpError(409, 'OUTBOX_EVENT_ALREADY_CLAIMED', 'notification_outbox event is already claimed', {
+            claimedBy: safeTextOrNull(row.claimed_by, 120),
+            lockedUntil: isoOrNull(row.locked_until)
+        });
+    }
+    if ((row.status === 'pending' || row.status === 'failed') && isFutureTimestamp(row.available_at)) {
+        throw notificationOutboxHttpError(409, 'OUTBOX_EVENT_NOT_AVAILABLE', 'notification_outbox event is not available yet', {
+            availableAt: isoOrNull(row.available_at)
+        });
+    }
+    throw notificationOutboxHttpError(409, 'OUTBOX_EVENT_NOT_CLAIMABLE', 'notification_outbox event cannot be claimed from its current status', {
+        status: row.status
+    });
+}
+
+async function findNotificationOutboxEventByEventId(eventId, options = {}) {
+    const query = options.pool || defaultPool;
+    const normalizedEventId = textOrNull(eventId);
+    if (!normalizedEventId) return null;
+
+    const result = await query.query(
+        `SELECT *
+         FROM notification_outbox
+         WHERE event_id = $1
+         LIMIT 1`,
+        [normalizedEventId]
+    );
+    return normalizeOutboxRow(result.rows?.[0] || null);
+}
+
+async function listNotificationOutboxEvents(filters = {}, options = {}) {
+    const query = options.pool || defaultPool;
+    const limit = normalizeNotificationOutboxLimit(filters.limit);
+    const status = filters.status === undefined || filters.status === null || filters.status === ''
+        ? 'pending'
+        : normalizeOutboxStatus(filters.status);
+    if (!status) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_INVALID_STATUS', 'Invalid notification_outbox status');
+    }
+
+    const ownerUserId = filters.ownerUserId === undefined || filters.ownerUserId === null || filters.ownerUserId === ''
+        ? null
+        : positiveIntegerOrNull(filters.ownerUserId);
+    if (filters.ownerUserId !== undefined && filters.ownerUserId !== null && filters.ownerUserId !== '' && !ownerUserId) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_INVALID_OWNER_USER_ID', 'ownerUserId must be a positive integer');
+    }
+
+    const eventType = filters.eventType === undefined || filters.eventType === null || filters.eventType === ''
+        ? null
+        : normalizeEventType(filters.eventType);
+    if (filters.eventType !== undefined && filters.eventType !== null && filters.eventType !== '' && !eventType) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_INVALID_EVENT_TYPE', 'Invalid notification_outbox eventType');
+    }
+
+    const cursor = normalizeCursor(filters.cursor);
+    const whereParts = ['status = $1'];
+    const params = [status];
+
+    if (status === 'pending' || status === 'failed') {
+        whereParts.push('(available_at IS NULL OR available_at <= NOW())');
+    }
+    if (ownerUserId) {
+        whereParts.push(`owner_user_id = ${pushSqlParam(params, ownerUserId)}`);
+    }
+    if (eventType) {
+        whereParts.push(`event_type = ${pushSqlParam(params, eventType)}`);
+    }
+    if (cursor) {
+        whereParts.push(`id > ${pushSqlParam(params, cursor)}`);
+    }
+
+    const limitParam = pushSqlParam(params, limit + 1);
+    const result = await query.query(
+        `SELECT *
+         FROM notification_outbox
+         WHERE ${whereParts.join(' AND ')}
+         ORDER BY id ASC
+         LIMIT ${limitParam}`,
+        params
+    );
+    const rows = (result.rows || []).map(normalizeOutboxRow);
+    const hasMore = rows.length > limit;
+    const events = rows.slice(0, limit);
+    const lastEvent = events[events.length - 1] || null;
+
+    return {
+        events,
+        pagination: {
+            limit,
+            hasMore,
+            nextCursor: hasMore && lastEvent?.id ? String(lastEvent.id) : null
+        }
+    };
+}
+
+async function getNotificationOutboxStats(options = {}) {
+    const query = options.pool || defaultPool;
+    const result = await query.query(
+        `SELECT
+             COUNT(*) FILTER (WHERE status = 'pending') AS pending,
+             COUNT(*) FILTER (WHERE status = 'claimed') AS claimed,
+             COUNT(*) FILTER (WHERE status = 'sent' AND sent_at >= NOW() - INTERVAL '24 hours') AS sent_24h,
+             COUNT(*) FILTER (WHERE status = 'failed') AS failed,
+             COUNT(*) FILTER (WHERE status = 'dead_letter') AS dead_letter,
+             COUNT(*) FILTER (WHERE status = 'skipped') AS skipped,
+             MIN(COALESCE(available_at, created_at)) FILTER (WHERE status = 'pending') AS oldest_pending_at,
+             MAX(sent_at) FILTER (WHERE status = 'sent') AS last_sent_at
+         FROM notification_outbox`
+    );
+    const row = result.rows?.[0] || {};
+    return {
+        stats: {
+            pending: Number(row.pending || 0),
+            claimed: Number(row.claimed || 0),
+            sent_24h: Number(row.sent_24h || 0),
+            failed: Number(row.failed || 0),
+            dead_letter: Number(row.dead_letter || 0),
+            skipped: Number(row.skipped || 0)
+        },
+        oldestPendingAt: isoOrNull(row.oldest_pending_at),
+        lastSentAt: isoOrNull(row.last_sent_at)
+    };
+}
+
+async function listNotificationOutboxDebugEvents(filters = {}, options = {}) {
+    const query = options.pool || defaultPool;
+    const limit = normalizeNotificationOutboxLimit(filters.limit);
+    const status = filters.status === undefined || filters.status === null || filters.status === ''
+        ? null
+        : normalizeOutboxStatus(filters.status);
+    if (filters.status !== undefined && filters.status !== null && filters.status !== '' && !status) {
+        throw notificationOutboxHttpError(400, 'OUTBOX_INVALID_STATUS', 'Invalid notification_outbox status');
+    }
+
+    const params = [limit];
+    const whereSql = status ? `WHERE status = ${pushSqlParam(params, status)}` : '';
+    const result = await query.query(
+        `SELECT
+             event_id,
+             task_id,
+             owner_user_id,
+             event_type,
+             status,
+             attempts,
+             created_at,
+             available_at,
+             last_error_code
+         FROM notification_outbox
+         ${whereSql}
+         ORDER BY created_at DESC, id DESC
+         LIMIT $1`,
+        params
+    );
+
+    return {
+        items: (result.rows || []).map(toNotificationOutboxDebugItem).filter(Boolean),
+        pagination: {
+            limit,
+            hasMore: false,
+            nextCursor: null
+        }
+    };
+}
+
+async function claimNotificationOutboxEvent(eventId, input = {}, options = {}) {
+    const query = options.pool || defaultPool;
+    const normalizedEventId = textOrNull(eventId);
+    if (!normalizedEventId) {
+        throw notificationOutboxHttpError(404, 'OUTBOX_EVENT_NOT_FOUND', 'notification_outbox event was not found');
+    }
+    const workerId = requireWorkerId(input.workerId || input.worker_id);
+    const lockSeconds = normalizeLockSeconds(input.lockSeconds || input.lock_seconds);
+
+    const claimed = await query.query(
+        `UPDATE notification_outbox
+         SET status = 'claimed',
+             claimed_at = NOW(),
+             claimed_by = $2,
+             locked_until = NOW() + ($3::int * INTERVAL '1 second'),
+             updated_at = NOW()
+         WHERE event_id = $1
+           AND status IN ('pending', 'failed', 'claimed')
+           AND (available_at IS NULL OR available_at <= NOW())
+           AND (status <> 'claimed' OR locked_until IS NULL OR locked_until <= NOW())
+         RETURNING *`,
+        [normalizedEventId, workerId, lockSeconds]
+    );
+    if (claimed.rows?.length) {
+        return {
+            event: normalizeOutboxRow(claimed.rows[0]),
+            claimed: true,
+            workerId,
+            lockSeconds
+        };
+    }
+
+    throwClaimConflict(await findNotificationOutboxEventByEventId(normalizedEventId, { pool: query }));
+}
+
+async function ackNotificationOutboxEvent(eventId, input = {}, options = {}) {
+    const query = options.pool || defaultPool;
+    const normalizedEventId = textOrNull(eventId);
+    if (!normalizedEventId) {
+        throw notificationOutboxHttpError(404, 'OUTBOX_EVENT_NOT_FOUND', 'notification_outbox event was not found');
+    }
+
+    const workerId = requireWorkerId(input.workerId || input.worker_id);
+    const channel = requireDeliveryChannel(input.channel);
+    const target = requireDeliveryTarget(input.target);
+    const sentAt = normalizeSentAt(input.sentAt || input.sent_at);
+    const existing = await findNotificationOutboxEventByEventId(normalizedEventId, { pool: query });
+    if (!existing) {
+        throw notificationOutboxHttpError(404, 'OUTBOX_EVENT_NOT_FOUND', 'notification_outbox event was not found');
+    }
+    if (existing.status === 'sent') {
+        return {
+            event: existing,
+            alreadySent: true,
+            workerId
+        };
+    }
+    assertClaimedByWorker(existing, workerId);
+
+    const updated = await query.query(
+        `UPDATE notification_outbox
+         SET status = 'sent',
+             sent_at = COALESCE($2::timestamptz, NOW()),
+             last_error = NULL,
+             last_error_code = NULL,
+             last_delivery_channel = $3,
+             last_delivery_target = $4,
+             locked_until = NULL,
+             updated_at = NOW()
+         WHERE event_id = $1
+         RETURNING *`,
+        [normalizedEventId, sentAt, channel, target]
+    );
+
+    return {
+        event: normalizeOutboxRow(updated.rows?.[0] || existing),
+        alreadySent: false,
+        workerId
+    };
+}
+
+async function failNotificationOutboxEvent(eventId, input = {}, options = {}) {
+    const query = options.pool || defaultPool;
+    const normalizedEventId = textOrNull(eventId);
+    if (!normalizedEventId) {
+        throw notificationOutboxHttpError(404, 'OUTBOX_EVENT_NOT_FOUND', 'notification_outbox event was not found');
+    }
+
+    const workerId = requireWorkerId(input.workerId || input.worker_id);
+    const errorCode = safeTextOrNull(input.errorCode || input.error_code, 120) || 'HERMES_DELIVERY_FAILED';
+    const errorMessage = safeTextOrNull(input.errorMessage || input.error_message || input.message, 500);
+    const retryable = input.retryable !== false;
+    const existing = await findNotificationOutboxEventByEventId(normalizedEventId, { pool: query });
+    if (!existing) {
+        throw notificationOutboxHttpError(404, 'OUTBOX_EVENT_NOT_FOUND', 'notification_outbox event was not found');
+    }
+    if (existing.status === 'sent') {
+        throw notificationOutboxHttpError(409, 'OUTBOX_EVENT_ALREADY_SENT', 'notification_outbox event is already sent');
+    }
+    if (existing.status === 'dead_letter' || existing.status === 'skipped') {
+        throw notificationOutboxHttpError(409, 'OUTBOX_EVENT_NOT_FAILABLE', 'notification_outbox event cannot be failed from its current status', {
+            status: existing.status
+        });
+    }
+    assertClaimedByWorker(existing, workerId);
+
+    const attempts = Number(existing.attempts || 0) + 1;
+    const status = retryable && attempts < DEAD_LETTER_ATTEMPT_THRESHOLD ? 'failed' : 'dead_letter';
+    const backoffMinutes = status === 'failed' ? NOTIFICATION_OUTBOX_RETRY_BACKOFF_MINUTES[attempts] || 120 : 0;
+
+    const updated = await query.query(
+        `UPDATE notification_outbox
+         SET status = $2,
+             attempts = $3,
+             available_at = CASE
+                 WHEN $2 = 'failed' THEN NOW() + ($4::int * INTERVAL '1 minute')
+                 ELSE NOW()
+             END,
+             last_error = $5,
+             last_error_code = $6,
+             locked_until = NULL,
+             updated_at = NOW()
+         WHERE event_id = $1
+         RETURNING *`,
+        [normalizedEventId, status, attempts, backoffMinutes, errorMessage, errorCode]
+    );
+
+    return {
+        event: normalizeOutboxRow(updated.rows?.[0] || existing),
+        retryable,
+        deadLetter: status === 'dead_letter',
+        attempts,
+        backoffMinutes,
+        workerId
+    };
+}
+
+async function createNotificationOutboxEvent(input = {}, options = {}) {
+    const query = options.pool || defaultPool;
+    const task = input.task || input;
+    const eventType = normalizeEventType(input.eventType || input.event_type || options.eventType || options.event_type);
+    const identity = requireTaskNotificationIdentity(task, eventType);
+    const rawPayload = input.payload || buildTaskNotificationPayload(task, {
+        ...(options.context || {}),
+        ...(input.context || {}),
+        eventType: identity.eventType
+    });
+    const payload = sanitizeTaskNotificationPayload(rawPayload);
+    const payloadHash = hashNotificationPayload(payload);
+    const eventId = textOrNull(input.eventId || input.event_id)
+        || generateNotificationEventId(task, identity.eventType);
+    const availableAt = input.availableAt || input.available_at || options.availableAt || null;
+
+    const inserted = await query.query(
+        `INSERT INTO notification_outbox (
+             event_id,
+             task_id,
+             owner_user_id,
+             event_type,
+             payload_json,
+             payload_hash,
+             status,
+             available_at
+         )
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6, 'pending', COALESCE($7::timestamptz, NOW()))
+         ON CONFLICT DO NOTHING
+         RETURNING *`,
+        [
+            eventId,
+            identity.taskId,
+            identity.ownerUserId,
+            identity.eventType,
+            JSON.stringify(payload),
+            payloadHash,
+            availableAt
+        ]
+    );
+
+    if (inserted.rows?.length) {
+        return {
+            event: normalizeOutboxRow(inserted.rows[0]),
+            created: true
+        };
+    }
+
+    const existing = await query.query(
+        `SELECT *
+         FROM notification_outbox
+         WHERE event_id = $1
+            OR (
+                task_id = $2
+                AND owner_user_id = $3
+                AND event_type = $4
+                AND payload_hash = $5
+            )
+         ORDER BY CASE WHEN event_id = $1 THEN 0 ELSE 1 END, id ASC
+         LIMIT 1`,
+        [eventId, identity.taskId, identity.ownerUserId, identity.eventType, payloadHash]
+    );
+
+    return {
+        event: normalizeOutboxRow(existing.rows?.[0] || null),
+        created: false
+    };
+}
+
+async function emitTaskCreatedNotificationOutboxEvent(task = {}, options = {}) {
+    const ownerUserId = normalizeOwnerUserId(task);
+    if (!ownerUserId) {
+        return { created: false, reason: 'no_owner_user_id' };
+    }
+    if (!isActiveTaskForHermesOutbox(task)) {
+        return { created: false, reason: 'inactive_task_status' };
+    }
+    if (options.skipHermesOutbox === true) {
+        return { created: false, reason: 'skip_hermes_outbox' };
+    }
+    if (!hermesTaskOutboxEnabled(options, options.env || process.env)) {
+        return { created: false, reason: 'hermes_task_outbox_disabled' };
+    }
+
+    return createNotificationOutboxEvent({
+        task,
+        eventType: 'task_created',
+        context: options.hermesOutboxContext || options.notificationContext || {}
+    }, {
+        pool: options.pool
+    });
+}
+
+module.exports = {
+    DEFAULT_NOTIFICATION_OUTBOX_LIMIT,
+    FUTURE_TASK_NOTIFICATION_EVENT_TYPES,
+    INITIAL_TASK_NOTIFICATION_EVENT_TYPES,
+    MAX_NOTIFICATION_OUTBOX_LIMIT,
+    NOTIFICATION_OUTBOX_STATUSES,
+    TASK_NOTIFICATION_EVENT_TYPES,
+    ackNotificationOutboxEvent,
+    buildTaskNotificationPayload,
+    claimNotificationOutboxEvent,
+    createNotificationOutboxEvent,
+    emitTaskCreatedNotificationOutboxEvent,
+    failNotificationOutboxEvent,
+    findNotificationOutboxEventByEventId,
+    generateNotificationEventId,
+    getNotificationOutboxStats,
+    hashNotificationPayload,
+    hermesTaskOutboxEnabled,
+    isActiveTaskForHermesOutbox,
+    listNotificationOutboxDebugEvents,
+    listNotificationOutboxEvents,
+    stableJsonStringify,
+    toNotificationOutboxApiEvent,
+    toNotificationOutboxDebugItem
+};

--- a/tests/hermes-notification-outbox.test.js
+++ b/tests/hermes-notification-outbox.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('minimal Hermes route exposes notification_outbox endpoints and auth gate', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../routes/hermes.js'), 'utf8');
+  assert.match(source, /notification-outbox/);
+  assert.match(source, /claimNotificationOutboxEvent/);
+  assert.match(source, /ackNotificationOutboxEvent/);
+  assert.match(source, /failNotificationOutboxEvent/);
+  assert.match(source, /HERMES_API_KEY/);
+});
+
+test('server mounts Hermes notification_outbox route before settings fallback', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../server.js'), 'utf8');
+  assert.match(source, /app\.use\('\/api\/hermes', require\('\.\/routes\/hermes'\)\)/);
+  assert.match(source, /req\.path\.startsWith\('\/hermes\/notification-outbox'\)/);
+});

--- a/tests/kleshnya-notification-outbox.test.js
+++ b/tests/kleshnya-notification-outbox.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('Kleshnya createTask has a soft Hermes notification_outbox hook', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../services/kleshnya.js'), 'utf8');
+  assert.match(source, /emitTaskCreatedNotificationOutboxEvent/);
+  assert.match(source, /async function createTask\(data, options = \{\}\)/);
+  assert.match(source, /owner_user_id: Number\.isInteger\(ownerUserId\)/);
+  assert.match(source, /skipHermesOutbox/);
+  assert.match(source, /\.catch\(err => log\.error\(`Hermes notification_outbox error/);
+});

--- a/tests/notification-outbox.test.js
+++ b/tests/notification-outbox.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildTaskNotificationPayload,
+  createNotificationOutboxEvent,
+  emitTaskCreatedNotificationOutboxEvent,
+  generateNotificationEventId,
+  hashNotificationPayload,
+  hermesTaskOutboxEnabled
+} = require('../services/notificationOutbox');
+
+test('notification_outbox payload is safe and deterministic', () => {
+  const task = {
+    id: 42,
+    title: ' Перевірити Hermes ',
+    status: 'todo',
+    priority: 'high',
+    owner_user_id: 4,
+    owner: 'Сергій',
+    deadline: '2026-06-30T12:00:00.000Z',
+    token: 'SECRET_SHOULD_NOT_APPEAR'
+  };
+  const payload = buildTaskNotificationPayload(task, { crmBaseUrl: 'https://crm.example' });
+  assert.equal(payload.taskId, 42);
+  assert.equal(payload.ownerUserId, 4);
+  assert.equal(payload.title, 'Перевірити Hermes');
+  assert.equal(payload.priority, 'high');
+  assert.match(payload.crmUrl, /https:\/\/crm\.example\/tasks\?open=42/);
+  assert.equal(Object.prototype.hasOwnProperty.call(payload, 'token'), false);
+  assert.equal(hashNotificationPayload(payload), hashNotificationPayload({ ...payload }));
+  assert.equal(generateNotificationEventId(task, 'task_created'), 'task_created:42:owner:4');
+});
+
+test('notification_outbox flags default safely by environment', () => {
+  assert.equal(hermesTaskOutboxEnabled({}, { NODE_ENV: 'production' }), false);
+  assert.equal(hermesTaskOutboxEnabled({}, { NODE_ENV: 'test' }), true);
+  assert.equal(hermesTaskOutboxEnabled({}, { HERMES_NOTIFICATION_OUTBOX_ENABLED: 'true' }), true);
+  assert.equal(hermesTaskOutboxEnabled({}, { HERMES_NOTIFICATION_OUTBOX_ENABLED: 'false', NODE_ENV: 'test' }), false);
+});
+
+test('emitTaskCreatedNotificationOutboxEvent no-ops without owner id', async () => {
+  const result = await emitTaskCreatedNotificationOutboxEvent({ id: 9, title: 'No owner' }, { env: { NODE_ENV: 'test' } });
+  assert.equal(result.created, false);
+  assert.equal(result.reason, 'no_owner_user_id');
+});
+
+test('createNotificationOutboxEvent inserts sanitized payload once', async () => {
+  const queries = [];
+  const fakePool = {
+    async query(sql, params) {
+      queries.push({ sql, params });
+      if (/INSERT INTO notification_outbox/.test(sql)) {
+        return { rows: [{
+          id: 1,
+          event_id: params[0],
+          task_id: params[1],
+          owner_user_id: params[2],
+          event_type: params[3],
+          payload_json: JSON.parse(params[4]),
+          payload_hash: params[5],
+          status: 'pending',
+          attempts: 0,
+          available_at: null,
+          created_at: new Date('2026-06-30T09:00:00Z'),
+          updated_at: new Date('2026-06-30T09:00:00Z')
+        }] };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    }
+  };
+  const result = await createNotificationOutboxEvent({
+    task: { id: 77, title: 'Task', owner_user_id: 4, priority: 'normal' },
+    eventType: 'task_created',
+    payload: { taskId: 77, ownerUserId: 4, title: 'Task', secret: 'drop-me' }
+  }, { pool: fakePool });
+  assert.equal(result.created, true);
+  assert.equal(result.event.event_id, 'task_created:77:owner:4');
+  assert.equal(result.event.payload_json.secret, undefined);
+  assert.equal(queries.length, 1);
+});


### PR DESCRIPTION
## Summary

Clean Event Genix Hermes `notification_outbox` branch from `origin/main`.

This is a narrow clean-branch replacement for the huge/outdated PR branch. Direct cherry-pick of the original outbox commits conflicted because `origin/main` does not contain several newer helper services/routes, so this PR ports the outbox as a clean-compatible minimal implementation instead of dragging unrelated history.

## Scope

- Adds additive `notification_outbox` migration.
- Adds `services/notificationOutbox.js` with safe payload normalization, idempotent event creation, lifecycle helpers, stats/list/debug helpers.
- Adds minimal `/api/hermes/notification-outbox*` worker endpoints.
- Adds soft Kleshnya task-created hook that no-ops unless a valid owner id is present and the outbox flag allows emission.
- Adds focused tests for outbox payload/service behavior, Hermes route mount/auth surface, and Kleshnya hook presence.

## Verification

```text
npx -y -p node@22 -p npm@10 -c "node --version && npm --version && node --test tests/notification-outbox.test.js tests/hermes-notification-outbox.test.js tests/kleshnya-notification-outbox.test.js"

node: v22.23.1
npm: 10.9.8
pass: 7
fail: 0
```

```text
git diff origin/main...HEAD --check
PASS
```

## Explicit non-actions

- No merge.
- No deploy.
- No production migration run.
- No Telegram/client messages.
- No cron/gateway changes.
- No secrets included.
