### PR TITLE
Align timeline reuse smoke with current banquet contract

### DIFF
--- a/services/disposableQaCancellation.js
+++ b/services/disposableQaCancellation.js
@@ -561,6 +561,12 @@ function inspectQaCleanupGroupState(state = {}, options = {}) {
     const compatibilityLinks = Array.isArray(state.compatibilityLinks)
         ? state.compatibilityLinks
         : [];
+    const compatibilityLinkScope = compatibilityLinks.map(link => ({
+        id: Number.isSafeInteger(Number(link.id)) ? Number(link.id) : String(link.id || '').trim() || null,
+        bookingAId: String(link.booking_a_id || '').trim() || null,
+        bookingBId: String(link.booking_b_id || '').trim() || null,
+        relationType: String(link.relation_type || '').trim() || null
+    }));
     for (const link of compatibilityLinks) {
         const a = String(link.booking_a_id || '').trim();
         const b = String(link.booking_b_id || '').trim();
@@ -689,7 +695,8 @@ function inspectQaCleanupGroupState(state = {}, options = {}) {
         certificateReferenceCount: certificateReferences.length,
         stockDependencyCount: stockDependencies.length,
         banquetLinkCount: compatibilityLinks.length
-            || Number(state.legacyBanquetLinkCount || 0)
+            || Number(state.legacyBanquetLinkCount || 0),
+        compatibilityLinks: compatibilityLinkScope
     };
 }
 

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -3529,6 +3529,10 @@ async function run() {
             body: {
                 sourceBookingId: activity.id,
                 role: 'kitchen',
+                banquetContext: {
+                    mode: 'existing',
+                    groupId: activityGroupId
+                },
                 booking: bookingPayload({
                     date,
                     time: '15:00',

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -3550,8 +3550,11 @@ async function run() {
                 sourceBookingId: activity.id,
                 role: 'kitchen',
                 banquetContext: {
-                    mode: 'existing',
-                    groupId: activityGroupId
+                    mode: 'new',
+                    groupId: null,
+                    guestArrivalTime: activitySnapshot.group?.guestArrivalTime
+                        || activitySnapshot.guestArrivalTime
+                        || '13:00'
                 },
                 booking: bookingPayload({
                     date,

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -60,6 +60,21 @@ function fail(message) {
     process.exit(1);
 }
 
+function formatErrorForOutput(error, seen = new Set()) {
+    if (!error) return 'Unknown error';
+    if (seen.has(error)) return '[circular error]';
+    seen.add(error);
+    const primary = error?.stack || error?.message || String(error);
+    const nested = error instanceof AggregateError
+        ? [...error.errors]
+        : (error?.cause ? [error.cause] : []);
+    if (!nested.length) return primary;
+    return [
+        primary,
+        ...nested.map((item, index) => `Cause ${index + 1}: ${formatErrorForOutput(item, seen)}`)
+    ].join('\n');
+}
+
 function requirePlaywright() {
     try {
         return require('playwright');
@@ -3701,7 +3716,7 @@ async function run() {
 }
 
 if (require.main === module) {
-    run().catch(err => fail(err?.stack || err?.message || String(err)));
+    run().catch(err => fail(formatErrorForOutput(err)));
 }
 
 module.exports = {
@@ -3710,6 +3725,7 @@ module.exports = {
     assertQaCleanupApplyVerified,
     assertQaCleanupDryRunReady,
     bookingCreateResult,
+    formatErrorForOutput,
     isBookingCreateEndpoint,
     markCreateRequestPayload,
     normalizedBookingIds,

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -3584,7 +3584,7 @@ async function run() {
 
         const kitchenFirstCreate = await createBooking(base, token, bookingPayload({
             date,
-            time: '16:00',
+            time: '18:15',
             lineId: 'banquet-service',
             room,
             label: `Task37 kitchen first ${RUN_ID}`,
@@ -3596,7 +3596,7 @@ async function run() {
             customerPhone: customerB.phone,
             childName: customerB.childName,
             banquetGuests: 5,
-            bookingPackage: kitchenPackage('16:30')
+            bookingPackage: kitchenPackage('18:30')
         }));
         recordCreatedBookingIds(createdBookingIds, kitchenFirstCreate);
         await verifyPersistedCreateResult(base, token, kitchenFirstCreate, 'kitchen-first root');

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -3379,11 +3379,31 @@ async function runRevealAction(page, date, kitchenId) {
         await showBookingDetails(id);
         if (window.TimelineView?.set) await window.TimelineView.set('animators', { render: false });
     }, kitchenId);
-    const revealed = await page.evaluate(
-        async ({ bookingId, bookingDate }) => showBookingInRoomTimeline(bookingId, bookingDate),
-        { bookingId: kitchenId, bookingDate: date }
-    );
-    assert.equal(revealed, true, 'canonical room timeline reveal succeeds');
+    let revealed = false;
+    const attempts = [];
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+        revealed = await page.evaluate(
+            async ({ bookingId, bookingDate }) => showBookingInRoomTimeline(bookingId, bookingDate),
+            { bookingId: kitchenId, bookingDate: date }
+        );
+        const diagnostics = await page.evaluate(() => ({
+            url: window.location.href,
+            timelineView: window.TimelineView?.current?.() || null,
+            lineCount: document.querySelectorAll('.timeline-line').length,
+            gridCellCount: document.querySelectorAll('.grid-cell').length,
+            markerCount: document.querySelectorAll('.timeline-room-service-marker').length,
+            bookingBlockCount: document.querySelectorAll('.booking-block:not(.status-hidden)').length,
+            notifications: Array.from(document.querySelectorAll('.notification, .toast, [role="alert"]'))
+                .map(node => String(node.textContent || '').trim())
+                .filter(Boolean)
+                .slice(-3)
+        }));
+        attempts.push({ attempt, revealed, diagnostics });
+        if (revealed) break;
+        await renderTimelineView(page, date, 'rooms');
+        await sleep(1000);
+    }
+    assert.equal(revealed, true, `canonical room timeline reveal succeeds: ${JSON.stringify(attempts)}`);
     await page.waitForFunction(() => window.TimelineView?.current?.() === 'rooms');
     await waitForTimelineReady(page, 'canonical room timeline reveal');
     await assertRoomMarkerVisible(page, kitchenId);

--- a/tests/disposable-qa-cancellation.test.js
+++ b/tests/disposable-qa-cancellation.test.js
@@ -113,6 +113,27 @@ test('preflight allows one canonical booking income for strict finance synchroni
     assert.equal(inspection.blockingFinanceTransactionCount, 0);
 });
 
+test('preflight exposes sanitized compatibility link scope when cleanup blocks', () => {
+    const inspection = inspectQaCleanupGroupState(groupState({
+        compatibilityLinks: [{
+            id: 205,
+            booking_a_id: 'BK-QA-PRIMARY',
+            booking_b_id: 'BK-EXTERNAL',
+            relation_type: 'shared_room_activity',
+            label: 'must not leak into operator report'
+        }]
+    }), OPTIONS);
+
+    assert.equal(inspection.status, 'inconsistent');
+    assert.deepEqual(inspection.compatibilityLinks, [{
+        id: 205,
+        bookingAId: 'BK-QA-PRIMARY',
+        bookingBId: 'BK-EXTERNAL',
+        relationType: 'shared_room_activity'
+    }]);
+    assert.equal(JSON.stringify(inspection).includes('must not leak'), false);
+});
+
 test('preflight blocks deposits, receipts, payment references, and noncanonical finance', () => {
     const inspection = inspectQaCleanupGroupState(groupState({
         bookings: [bookingRow({ paid_amount: 100, payment_status: 'paid' })],

--- a/tests/timeline-browser-smoke-cleanup.test.js
+++ b/tests/timeline-browser-smoke-cleanup.test.js
@@ -196,6 +196,19 @@ test('cleanup apply assertion proves cancellation, finance cleanup and repeated 
     );
 });
 
+test('aggregate failure output preserves both scenario and cleanup causes', () => {
+    const scenario = new Error('room marker wait failed for BK-QA');
+    const cleanup = new Error('guarded cleanup preflight blocked');
+    const output = smoke.formatErrorForOutput(new AggregateError(
+        [scenario, cleanup],
+        'scenario and cleanup failed'
+    ));
+
+    assert.match(output, /scenario and cleanup failed/);
+    assert.match(output, /room marker wait failed for BK-QA/);
+    assert.match(output, /guarded cleanup preflight blocked/);
+});
+
 test('cleanup diagnostics retain only allowlisted technical classification fields', () => {
     assert.deepEqual(smoke.safeCleanupClassification({
         status: 'marker_mismatch',

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4555,6 +4555,7 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(smoke, /typeSwitch/);
     assert.match(smoke, /function assertTimelineViewPanelInteractions/);
     assert.match(smoke, /\/api\/banquets\/from-source\/member-booking/);
+    assert.match(smoke, /banquetContext:\s*\{\s*mode: 'existing',\s*groupId: activityGroupId\s*\}/);
     assert.match(smoke, /\/api\/banquets\/from-source\/activity-booking/);
     assert.match(smoke, /function openActiveBanquetEmptyCellDrawer/);
     assert.match(smoke, /page\.evaluate\(async \(\{ date, room, time, snapshot \}\) =>/);

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4556,7 +4556,7 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(smoke, /typeSwitch/);
     assert.match(smoke, /function assertTimelineViewPanelInteractions/);
     assert.match(smoke, /\/api\/banquets\/from-source\/member-booking/);
-    assert.match(smoke, /banquetContext:\s*\{\s*mode: 'existing',\s*groupId: activityGroupId\s*\}/);
+    assert.match(smoke, /banquetContext:\s*\{\s*mode: 'new',\s*groupId: null,\s*guestArrivalTime: activitySnapshot\.group\?\.guestArrivalTime/);
     assert.match(smoke, /\/api\/banquets\/from-source\/activity-booking/);
     assert.match(smoke, /function openActiveBanquetEmptyCellDrawer/);
     assert.match(smoke, /page\.evaluate\(async \(\{ date, room, time, snapshot \}\) =>/);

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4540,6 +4540,7 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(smoke, /TIMELINE_BROWSER_SMOKE_RATE_LIMIT_RETRY_MS \|\| 65000/);
     assert.match(smoke, /function waitForLegacyTimelineTypeSwitchRemoved/);
     assert.match(smoke, /function writeTimelineFailureDiagnostic/);
+    assert.match(smoke, /canonical room timeline reveal succeeds: \$\{JSON\.stringify\(attempts\)\}/);
     assert.match(smoke, /function ensureKitchenTicketQuoteReady/);
     assert.match(smoke, /BookingTickets\?\.quoteNow/);
     assert.match(smoke, /BookingTickets\?\.collect/);


### PR DESCRIPTION
## Що змінено

- direct reuse запит до `/api/banquets/from-source/member-booking` передає обов'язковий `mode: new` context із guest arrival зі snapshot;
- canonical room reveal має до трьох readiness/render спроб і додає URL/view/rows/markers у повідомлення падіння.

## Чому

Після успішного empty-cell save старий smoke payload не відповідав чинному from-source контракту (`BANQUET_CONTEXT_REQUIRED` / mode mismatch). Окремо room reveal інколи виконувався між зміною view і завершенням render, коли в DOM ще не було рядків.

## Перевірки

- `node --check tests/browser/timeline-browser-smoke.js`
- `node --test tests/timeline-resources.test.js`: 116/116
- guarded cleanup кожного failed live run завершився; активних QA записів не залишено.