### PR TITLE
Stabilize timeline live smoke rate-limit recovery

### DIFF
--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -463,6 +463,37 @@ async function findBookingTimeSmokeSlot(base, token, room) {
     throw new Error('no visible free animator line found for the 12:15 -> 12:30 booking time smoke');
 }
 
+async function findKitchenFirstSmokeDate(base, token, room, startDate, excludedDates = []) {
+    const excluded = new Set(excludedDates.filter(Boolean));
+    for (let offset = 0; offset < 45; offset += 1) {
+        const date = datePlus(startDate, offset);
+        if (excluded.has(date)) continue;
+        const line = await firstAnimatorLine(base, token, date);
+        const bookings = await fetchJsonWithRetry(
+            base,
+            scopedPath(`/api/bookings/${encodeURIComponent(date)}`, { timelineView: 'animators' }),
+            { token },
+            {
+                attempts: 3,
+                delayMs: RATE_LIMIT_RETRY_MS,
+                label: `kitchen-first availability ${date}`
+            }
+        );
+        const normalizedRoom = String(room || '').trim().toLowerCase();
+        const conflict = (Array.isArray(bookings) ? bookings : []).some(booking => {
+            if (String(booking?.status || '').toLowerCase() === 'cancelled') return false;
+            if (!smokeBookingOverlaps(booking, '13:00', 90)) return false;
+            const sameLine = [booking?.lineId, booking?.line_id, booking?.resourceId, booking?.resource_id]
+                .some(value => String(value || '') === String(line.id));
+            const sameRoom = normalizedRoom
+                && String(booking?.room || '').trim().toLowerCase() === normalizedRoom;
+            return sameLine || sameRoom;
+        });
+        if (!conflict) return date;
+    }
+    throw new Error('no free room and first animator line found for kitchen-first smoke');
+}
+
 function bookingPayload(base = {}) {
     const payload = {
         businessContext: BUSINESS_CONTEXT,
@@ -1416,7 +1447,7 @@ async function openRoomDrawer(page, date, room, time) {
 }
 
 function assertBridgeSelector(result, label) {
-    assert.equal(result.ok, true, `${label}: drawer opens`);
+    assert.equal(result.ok, true, `${label}: drawer opens; result=${JSON.stringify(result)}`);
     assert.equal(result.panelVisible, true, `${label}: drawer visible`);
     const combined = `${result.selectorText || ''} ${result.hintText || ''}`.replace(/\s+/g, ' ').trim();
     assert.ok(!/^Без прив.?язки$/i.test(combined), `${label}: selector is not only "Без прив'язки"`);
@@ -3496,6 +3527,7 @@ async function run() {
     const createdBanquetCleanupTargets = [];
     const bookingCapture = createBookingResponseCapture(createdBookingIds);
     let bookingTimeDate = date;
+    let kitchenFirstDate = secondDate;
     let scenarioFailure = null;
 
     const browser = await playwright.chromium.launch({ headless: HEADLESS });
@@ -3505,6 +3537,13 @@ async function run() {
         const animator = await firstAnimatorLine(base, token, date);
         const bookingTimeSlot = await findBookingTimeSmokeSlot(base, token, room);
         bookingTimeDate = bookingTimeSlot.date;
+        kitchenFirstDate = await findKitchenFirstSmokeDate(
+            base,
+            token,
+            room,
+            secondDate,
+            [date, bookingTimeDate]
+        );
         const customerA = await createCustomer(base, token, 'activity-first');
         createdCustomerIds.push(customerA.id);
         const customerB = await createCustomer(base, token, 'kitchen-first');
@@ -3642,7 +3681,7 @@ async function run() {
         );
 
         const kitchenFirstCreate = await createBooking(base, token, bookingPayload({
-            date: secondDate,
+            date: kitchenFirstDate,
             time: '13:00',
             lineId: 'banquet-service',
             room,
@@ -3661,9 +3700,9 @@ async function run() {
         await verifyPersistedCreateResult(base, token, kitchenFirstCreate, 'kitchen-first root');
         const kitchenFirst = kitchenFirstCreate.booking;
 
-        await renderTimelineView(page, secondDate, 'rooms', { forceBookings: true });
+        await renderTimelineView(page, kitchenFirstDate, 'rooms', { forceBookings: true });
         await assertRoomMarkerVisible(page, kitchenFirst.id);
-        const kitchenFirstDrawer = await openActivityFromKitchenSource(page, secondDate, kitchenFirst.id);
+        const kitchenFirstDrawer = await openActivityFromKitchenSource(page, kitchenFirstDate, kitchenFirst.id);
         assertBridgeSelector(kitchenFirstDrawer, 'kitchen first -> activity');
         const program = await chooseFirstActivityProgram(page);
         assert.ok(program?.id, 'activity program selected for kitchen-first bridge');
@@ -3677,9 +3716,9 @@ async function run() {
             ...activityFromKitchen.bookingIds
         ]);
 
-        await renderTimelineView(page, secondDate, 'rooms');
+        await renderTimelineView(page, kitchenFirstDate, 'rooms');
         await assertRoomMarkerVisible(page, kitchenFirst.id);
-        await renderTimelineView(page, secondDate, 'animators');
+        await renderTimelineView(page, kitchenFirstDate, 'animators');
         await assertBookingBlockVisible(page, activityFromKitchen.booking.id);
         const kitchenFirstAnimatorVisible = await page.evaluate(id => {
             const escaped = CSS.escape(String(id));

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -2618,7 +2618,12 @@ async function submitActivityFromKitchen(page) {
     await acknowledgePreorderWarningIfVisible(page, 'source kitchen -> activity');
     const response = await responsePromise;
     const body = await response.json();
-    assert.equal(response.ok(), true, 'source kitchen -> activity endpoint returns ok');
+    const responseDiagnostic = JSON.stringify({
+        status: response.status(),
+        code: body?.code || null,
+        error: body?.error || body?.message || null
+    });
+    assert.equal(response.ok(), true, `source kitchen -> activity endpoint returns ok: ${responseDiagnostic}`);
     assert.equal(body.success, true, 'source kitchen -> activity response success');
     return bookingCreateResult(body);
 }
@@ -3717,7 +3722,6 @@ async function run() {
             customerName: customerB.name,
             customerPhone: customerB.phone,
             childName: customerB.childName,
-            banquetGuests: 5,
             bookingPackage: kitchenPackage('13:15')
         }));
         recordCreatedBookingIds(createdBookingIds, kitchenFirstCreate);

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -955,7 +955,16 @@ async function cleanupBanquetGroups(base, token, bookingIds, knownTargets = [], 
 }
 
 async function banquetSnapshot(base, token, bookingId) {
-    return fetchJson(base, scopedPath(`/api/banquets/by-booking/${encodeURIComponent(bookingId)}`), { token });
+    return fetchJsonWithRetry(
+        base,
+        scopedPath(`/api/banquets/by-booking/${encodeURIComponent(bookingId)}`),
+        { token },
+        {
+            attempts: 3,
+            delayMs: RATE_LIMIT_RETRY_MS,
+            label: `banquet snapshot ${bookingId}`
+        }
+    );
 }
 
 function groupId(snapshot = {}) {

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -468,7 +468,12 @@ async function findKitchenFirstSmokeDate(base, token, room, startDate, excludedD
     for (let offset = 0; offset < 45; offset += 1) {
         const date = datePlus(startDate, offset);
         if (excluded.has(date)) continue;
-        const line = await firstAnimatorLine(base, token, date);
+        const lines = await loadLines(base, token, date, 'animators');
+        const line = lines.find(item => (
+            String(item?.id || '')
+            && !['afisha', 'banquet-service'].includes(String(item.id))
+        ));
+        if (!line) continue;
         const bookings = await fetchJsonWithRetry(
             base,
             scopedPath(`/api/bookings/${encodeURIComponent(date)}`, { timelineView: 'animators' }),

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -1358,19 +1358,22 @@ async function openAuthenticatedPage(browser, base, session, bookingCapture = nu
     return { context, page };
 }
 
-async function renderTimelineView(page, date, view) {
+async function renderTimelineView(page, date, view, { forceBookings = false } = {}) {
     let lastError = null;
     for (let attempt = 1; attempt <= 3; attempt += 1) {
         try {
             await waitForTimelineReady(page, `before render timeline ${view} ${date}`);
-            await page.evaluate(async ({ date, view }) => {
+            await page.evaluate(async ({ date, view, forceBookings }) => {
                 AppState.selectedDate = new Date(`${date}T00:00:00`);
                 const input = document.getElementById('timelineDate');
                 if (input) input.value = date;
                 if (typeof setTimelineDateInUrl === 'function') setTimelineDateInUrl(date);
                 if (window.TimelineView?.set) await window.TimelineView.set(view, { render: false });
+                if (forceBookings && typeof invalidateTimelineDateCache === 'function') {
+                    invalidateTimelineDateCache(date, { lines: false, bookings: true });
+                }
                 if (typeof renderTimeline === 'function') await renderTimeline();
-            }, { date, view });
+            }, { date, view, forceBookings });
             await waitForTimelineReady(page, `after render timeline ${view} ${date}`);
             return;
         } catch (error) {
@@ -3640,7 +3643,7 @@ async function run() {
         await verifyPersistedCreateResult(base, token, kitchenFirstCreate, 'kitchen-first root');
         const kitchenFirst = kitchenFirstCreate.booking;
 
-        await renderTimelineView(page, secondDate, 'rooms');
+        await renderTimelineView(page, secondDate, 'rooms', { forceBookings: true });
         await assertRoomMarkerVisible(page, kitchenFirst.id);
         const kitchenFirstDrawer = await openActivityFromKitchenSource(page, secondDate, kitchenFirst.id);
         assertBridgeSelector(kitchenFirstDrawer, 'kitchen first -> activity');

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -310,7 +310,8 @@ function sleep(ms) {
 }
 
 function isRateLimitError(error) {
-    return /\breturned 429\b/.test(String(error?.message || error || ''));
+    return /\breturned 429\b|HTTP\s*429|Забагато запитів/i
+        .test(String(error?.message || error || ''));
 }
 
 function isTimelineRateLimited(diagnostics = {}) {
@@ -3408,10 +3409,27 @@ async function assertTimelineHeaderAnd15MinuteGeometry(page, date, bookingId) {
 
 async function runRevealAction(page, date, kitchenId) {
     await renderTimelineView(page, date, 'rooms');
-    await page.evaluate(async id => {
-        await showBookingDetails(id);
-        if (window.TimelineView?.set) await window.TimelineView.set('animators', { render: false });
-    }, kitchenId);
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+        try {
+            await page.evaluate(async id => {
+                await showBookingDetails(id);
+                if (window.TimelineView?.set) await window.TimelineView.set('animators', { render: false });
+            }, kitchenId);
+            break;
+        } catch (error) {
+            if (!isRateLimitError(error) || attempt >= 2) {
+                throw new Error(
+                    `canonical booking detail readiness failed before room reveal: ${error?.message || error}`,
+                    { cause: error }
+                );
+            }
+            console.warn(`canonical booking detail readiness: HTTP 429, retrying after ${RATE_LIMIT_RETRY_MS}ms`);
+            await sleep(RATE_LIMIT_RETRY_MS);
+            await page.reload({ waitUntil: 'domcontentloaded' });
+            await waitForTimelineReady(page, 'canonical booking detail after rate-limit reload');
+            await renderTimelineView(page, date, 'rooms', { forceBookings: true });
+        }
+    }
     let revealed = false;
     const attempts = [];
     let rateLimitBackoffs = 0;
@@ -3753,6 +3771,7 @@ module.exports = {
     bookingCreateResult,
     formatErrorForOutput,
     isBookingCreateEndpoint,
+    isRateLimitError,
     isTimelineRateLimited,
     markCreateRequestPayload,
     normalizedBookingIds,

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -1676,6 +1676,23 @@ async function acknowledgePreorderWarningIfVisible(page, label) {
     return true;
 }
 
+async function acknowledgeGuestArrivalPromptIfVisible(page, label) {
+    const overlay = page.locator('.confirm-overlay').filter({
+        has: page.locator('.confirm-message', { hasText: /Час приходу гостей/i })
+    }).last();
+    const visible = await overlay.waitFor({ state: 'visible', timeout: 3000 })
+        .then(() => true)
+        .catch(() => false);
+    if (!visible) return false;
+    const input = overlay.locator('.prompt-input');
+    if (!String(await input.inputValue()).trim()) await input.fill('13:00');
+    await overlay.locator('.confirm-ok').click();
+    await overlay.waitFor({ state: 'detached', timeout: 5000 }).catch(error => {
+        throw new Error(`${label}: guest arrival prompt did not close: ${error?.message || error}`);
+    });
+    return true;
+}
+
 async function fillKitchenAndSubmit(page, sourceBookingId) {
     const sourceBooking = sourceBookingId && typeof sourceBookingId === 'object' ? sourceBookingId : { id: sourceBookingId };
     sourceBookingId = sourceBookingIdOf(sourceBooking);
@@ -2594,8 +2611,10 @@ async function submitActivityFromKitchen(page) {
     );
     await page.evaluate(() => {
         document.getElementById('bookingNotes').value = 'Task37 activity browser smoke';
-        document.getElementById('bookingForm').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     });
+    await page.locator('#bookingForm .btn-submit').scrollIntoViewIfNeeded();
+    await page.locator('#bookingForm .btn-submit').click();
+    await acknowledgeGuestArrivalPromptIfVisible(page, 'source kitchen -> activity');
     await acknowledgePreorderWarningIfVisible(page, 'source kitchen -> activity');
     const response = await responsePromise;
     const body = await response.json();

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -313,6 +313,12 @@ function isRateLimitError(error) {
     return /\breturned 429\b/.test(String(error?.message || error || ''));
 }
 
+function isTimelineRateLimited(diagnostics = {}) {
+    return (diagnostics.notifications || []).some(message => (
+        /HTTP\s*429|Забагато запитів/i.test(String(message || ''))
+    ));
+}
+
 async function readBody(res) {
     const text = await res.text();
     try {
@@ -832,7 +838,16 @@ async function verifyCancelledBanquetSnapshot(base, token, target) {
     assert.ok(anchorId, `cancelled snapshot anchor exists for ${target.groupId}`);
     let snapshot;
     try {
-        snapshot = await banquetSnapshot(base, token, anchorId);
+        snapshot = await fetchJsonWithRetry(
+            base,
+            scopedPath(`/api/banquets/by-booking/${encodeURIComponent(anchorId)}`),
+            { token },
+            {
+                attempts: 3,
+                delayMs: RATE_LIMIT_RETRY_MS,
+                label: `cancelled banquet snapshot ${target.groupId}`
+            }
+        );
     } catch (error) {
         assert.match(
             String(error?.message || error),
@@ -3396,7 +3411,8 @@ async function runRevealAction(page, date, kitchenId) {
     }, kitchenId);
     let revealed = false;
     const attempts = [];
-    for (let attempt = 1; attempt <= 3; attempt += 1) {
+    let rateLimitBackoffs = 0;
+    for (let attempt = 1; attempt <= 4; attempt += 1) {
         revealed = await page.evaluate(
             async ({ bookingId, bookingDate }) => showBookingInRoomTimeline(bookingId, bookingDate),
             { bookingId: kitchenId, bookingDate: date }
@@ -3415,6 +3431,13 @@ async function runRevealAction(page, date, kitchenId) {
         }));
         attempts.push({ attempt, revealed, diagnostics });
         if (revealed) break;
+        if (isTimelineRateLimited(diagnostics) && rateLimitBackoffs < 1) {
+            rateLimitBackoffs += 1;
+            console.warn(`canonical room timeline reveal: HTTP 429, retrying after ${RATE_LIMIT_RETRY_MS}ms`);
+            await sleep(RATE_LIMIT_RETRY_MS);
+            await page.reload({ waitUntil: 'domcontentloaded' });
+            await waitForTimelineReady(page, 'canonical room timeline reveal after rate-limit reload');
+        }
         await renderTimelineView(page, date, 'rooms');
         await sleep(1000);
     }
@@ -3598,8 +3621,8 @@ async function run() {
         );
 
         const kitchenFirstCreate = await createBooking(base, token, bookingPayload({
-            date,
-            time: '18:15',
+            date: secondDate,
+            time: '13:00',
             lineId: 'banquet-service',
             room,
             label: `Task37 kitchen first ${RUN_ID}`,
@@ -3611,15 +3634,15 @@ async function run() {
             customerPhone: customerB.phone,
             childName: customerB.childName,
             banquetGuests: 5,
-            bookingPackage: kitchenPackage('18:30')
+            bookingPackage: kitchenPackage('13:15')
         }));
         recordCreatedBookingIds(createdBookingIds, kitchenFirstCreate);
         await verifyPersistedCreateResult(base, token, kitchenFirstCreate, 'kitchen-first root');
         const kitchenFirst = kitchenFirstCreate.booking;
 
-        await renderTimelineView(page, date, 'rooms');
+        await renderTimelineView(page, secondDate, 'rooms');
         await assertRoomMarkerVisible(page, kitchenFirst.id);
-        const kitchenFirstDrawer = await openActivityFromKitchenSource(page, date, kitchenFirst.id);
+        const kitchenFirstDrawer = await openActivityFromKitchenSource(page, secondDate, kitchenFirst.id);
         assertBridgeSelector(kitchenFirstDrawer, 'kitchen first -> activity');
         const program = await chooseFirstActivityProgram(page);
         assert.ok(program?.id, 'activity program selected for kitchen-first bridge');
@@ -3633,9 +3656,9 @@ async function run() {
             ...activityFromKitchen.bookingIds
         ]);
 
-        await renderTimelineView(page, date, 'rooms');
+        await renderTimelineView(page, secondDate, 'rooms');
         await assertRoomMarkerVisible(page, kitchenFirst.id);
-        await renderTimelineView(page, date, 'animators');
+        await renderTimelineView(page, secondDate, 'animators');
         await assertBookingBlockVisible(page, activityFromKitchen.booking.id);
         const kitchenFirstAnimatorVisible = await page.evaluate(id => {
             const escaped = CSS.escape(String(id));
@@ -3727,6 +3750,7 @@ module.exports = {
     bookingCreateResult,
     formatErrorForOutput,
     isBookingCreateEndpoint,
+    isTimelineRateLimited,
     markCreateRequestPayload,
     normalizedBookingIds,
     safeCleanupClassification,

--- a/tests/browser/timeline-browser-smoke.js
+++ b/tests/browser/timeline-browser-smoke.js
@@ -1162,6 +1162,10 @@ async function collectTimelineDiagnostics(page, label, error = null) {
                 bookingBlockCount: document.querySelectorAll('.booking-block').length,
                 lineCount: document.querySelectorAll('.timeline-line, .line-row, .line-grid').length
             },
+            timelineDataError: (() => {
+                const node = document.querySelector('.timeline-data-error');
+                return node ? String(node.textContent || '').replace(/\s+/g, ' ').trim() : '';
+            })(),
             typeSwitch: {
                 exists: Boolean(selector),
                 visible: visibleFrom(selector, selectorRect, selectorStyle),
@@ -1400,7 +1404,7 @@ async function renderTimelineView(page, date, view, { forceBookings = false } = 
     for (let attempt = 1; attempt <= 3; attempt += 1) {
         try {
             await waitForTimelineReady(page, `before render timeline ${view} ${date}`);
-            await page.evaluate(async ({ date, view, forceBookings }) => {
+            const renderState = await page.evaluate(async ({ date, view, forceBookings }) => {
                 AppState.selectedDate = new Date(`${date}T00:00:00`);
                 const input = document.getElementById('timelineDate');
                 if (input) input.value = date;
@@ -1409,12 +1413,29 @@ async function renderTimelineView(page, date, view, { forceBookings = false } = 
                 if (forceBookings && typeof invalidateTimelineDateCache === 'function') {
                     invalidateTimelineDateCache(date, { lines: false, bookings: true });
                 }
-                if (typeof renderTimeline === 'function') await renderTimeline();
+                const rendered = typeof renderTimeline === 'function' ? await renderTimeline() : false;
+                const errorNode = document.querySelector('.timeline-data-error');
+                return {
+                    rendered,
+                    errorText: errorNode
+                        ? String(errorNode.textContent || '').replace(/\s+/g, ' ').trim()
+                        : ''
+                };
             }, { date, view, forceBookings });
+            if (renderState.errorText) {
+                throw new Error(`timeline render error: ${renderState.errorText}`);
+            }
             await waitForTimelineReady(page, `after render timeline ${view} ${date}`);
             return;
         } catch (error) {
             lastError = error;
+            if (isRateLimitError(error) && attempt < 3) {
+                console.warn(`render timeline ${view} ${date}: HTTP 429, retrying after ${RATE_LIMIT_RETRY_MS}ms`);
+                await sleep(RATE_LIMIT_RETRY_MS);
+                await page.reload({ waitUntil: 'domcontentloaded' });
+                await waitForTimelineReady(page, `rate-limit reload timeline ${view} ${date}`);
+                continue;
+            }
             if (!isNavigationContextError(error) && attempt >= 2) break;
             await page.waitForLoadState('domcontentloaded').catch(() => {});
             await page.waitForTimeout(250);

--- a/tests/timeline-browser-smoke-cleanup.test.js
+++ b/tests/timeline-browser-smoke-cleanup.test.js
@@ -209,6 +209,15 @@ test('aggregate failure output preserves both scenario and cleanup causes', () =
     assert.match(output, /guarded cleanup preflight blocked/);
 });
 
+test('timeline rate-limit diagnostic recognizes the rendered HTTP 429 state', () => {
+    assert.equal(smoke.isTimelineRateLimited({
+        notifications: ['Не вдалося завантажити бронювання · HTTP 429']
+    }), true);
+    assert.equal(smoke.isTimelineRateLimited({
+        notifications: ['Бронювання створено!']
+    }), false);
+});
+
 test('cleanup diagnostics retain only allowlisted technical classification fields', () => {
     assert.deepEqual(smoke.safeCleanupClassification({
         status: 'marker_mismatch',

--- a/tests/timeline-browser-smoke-cleanup.test.js
+++ b/tests/timeline-browser-smoke-cleanup.test.js
@@ -216,6 +216,7 @@ test('timeline rate-limit diagnostic recognizes the rendered HTTP 429 state', ()
     assert.equal(smoke.isTimelineRateLimited({
         notifications: ['Бронювання створено!']
     }), false);
+    assert.equal(smoke.isRateLimitError(new Error('Забагато запитів, спробуйте пізніше')), true);
 });
 
 test('cleanup diagnostics retain only allowlisted technical classification fields', () => {

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4578,6 +4578,7 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(smoke, /kitchen first -> activity/);
     assert.match(smoke, /date: secondDate,\s*time: '13:00'/);
     assert.doesNotMatch(smoke, /time: '18:15'/);
+    assert.match(smoke, /secondDate, 'rooms', \{ forceBookings: true \}/);
     assert.match(smoke, /Банкетів цього клієнта на дату не знайдено/);
     assert.match(smoke, /Без прив.?язки/);
     assert.match(smoke, /function waitForLegacyTimelineTypeSwitchRemoved/);

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4570,6 +4570,12 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(emptyCellSubmit, /clickActiveBanquetMemberSubmit/);
     assert.match(emptyCellSubmit, /setBookingKitchenEnabled\(false/);
     assert.doesNotMatch(emptyCellSubmit, /dispatchEvent\(new Event\('submit'/);
+    const kitchenActivitySubmitStart = smoke.indexOf('async function submitActivityFromKitchen');
+    const kitchenActivitySubmitEnd = smoke.indexOf('async function assertRoomMarkerVisible', kitchenActivitySubmitStart);
+    const kitchenActivitySubmit = smoke.slice(kitchenActivitySubmitStart, kitchenActivitySubmitEnd);
+    assert.match(kitchenActivitySubmit, /acknowledgeGuestArrivalPromptIfVisible/);
+    assert.match(kitchenActivitySubmit, /locator\('#bookingForm \.btn-submit'\)\.click\(\)/);
+    assert.doesNotMatch(kitchenActivitySubmit, /dispatchEvent\(new Event\('submit'/);
     assert.match(smoke, /active inspector -> empty cell/);
     assert.match(smoke, /\/api\/banquets\/\$\{encodeURIComponent\(groupId\)\}\/member-booking/);
     assert.match(smoke, /genericBookingRequests/);

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4587,6 +4587,7 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(smoke, /kitchenFirstDate, 'rooms', \{ forceBookings: true \}/);
     assert.match(smoke, /findKitchenFirstSmokeDate/);
     assert.match(smoke, /source kitchen -> activity endpoint returns ok: \$\{responseDiagnostic\}/);
+    assert.match(smoke, /timeline render error: \$\{renderState\.errorText\}/);
     const kitchenFirstCreateStart = smoke.indexOf('const kitchenFirstCreate = await createBooking');
     const kitchenFirstCreateEnd = smoke.indexOf('recordCreatedBookingIds(createdBookingIds, kitchenFirstCreate)', kitchenFirstCreateStart);
     assert.doesNotMatch(

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4576,6 +4576,8 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(smoke, /does not use generic booking endpoints/);
     assert.match(smoke, /activity first -> kitchen/);
     assert.match(smoke, /kitchen first -> activity/);
+    assert.match(smoke, /date: secondDate,\s*time: '13:00'/);
+    assert.doesNotMatch(smoke, /time: '18:15'/);
     assert.match(smoke, /Банкетів цього клієнта на дату не знайдено/);
     assert.match(smoke, /Без прив.?язки/);
     assert.match(smoke, /function waitForLegacyTimelineTypeSwitchRemoved/);

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4576,9 +4576,10 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(smoke, /does not use generic booking endpoints/);
     assert.match(smoke, /activity first -> kitchen/);
     assert.match(smoke, /kitchen first -> activity/);
-    assert.match(smoke, /date: secondDate,\s*time: '13:00'/);
+    assert.match(smoke, /date: kitchenFirstDate,\s*time: '13:00'/);
     assert.doesNotMatch(smoke, /time: '18:15'/);
-    assert.match(smoke, /secondDate, 'rooms', \{ forceBookings: true \}/);
+    assert.match(smoke, /kitchenFirstDate, 'rooms', \{ forceBookings: true \}/);
+    assert.match(smoke, /findKitchenFirstSmokeDate/);
     assert.match(smoke, /Банкетів цього клієнта на дату не знайдено/);
     assert.match(smoke, /Без прив.?язки/);
     assert.match(smoke, /function waitForLegacyTimelineTypeSwitchRemoved/);

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4588,6 +4588,7 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.match(smoke, /findKitchenFirstSmokeDate/);
     assert.match(smoke, /source kitchen -> activity endpoint returns ok: \$\{responseDiagnostic\}/);
     assert.match(smoke, /timeline render error: \$\{renderState\.errorText\}/);
+    assert.match(smoke, /label: `banquet snapshot \$\{bookingId\}`/);
     const kitchenFirstCreateStart = smoke.indexOf('const kitchenFirstCreate = await createBooking');
     const kitchenFirstCreateEnd = smoke.indexOf('recordCreatedBookingIds(createdBookingIds, kitchenFirstCreate)', kitchenFirstCreateStart);
     assert.doesNotMatch(

--- a/tests/timeline-resources.test.js
+++ b/tests/timeline-resources.test.js
@@ -4586,6 +4586,14 @@ test('timeline browser smoke runner covers two-way banquet bridge regressions', 
     assert.doesNotMatch(smoke, /time: '18:15'/);
     assert.match(smoke, /kitchenFirstDate, 'rooms', \{ forceBookings: true \}/);
     assert.match(smoke, /findKitchenFirstSmokeDate/);
+    assert.match(smoke, /source kitchen -> activity endpoint returns ok: \$\{responseDiagnostic\}/);
+    const kitchenFirstCreateStart = smoke.indexOf('const kitchenFirstCreate = await createBooking');
+    const kitchenFirstCreateEnd = smoke.indexOf('recordCreatedBookingIds(createdBookingIds, kitchenFirstCreate)', kitchenFirstCreateStart);
+    assert.doesNotMatch(
+        smoke.slice(kitchenFirstCreateStart, kitchenFirstCreateEnd),
+        /banquetGuests/,
+        'kitchen-first bridge source must stay non-ticketed'
+    );
     assert.match(smoke, /Банкетів цього клієнта на дату не знайдено/);
     assert.match(smoke, /Без прив.?язки/);
     assert.match(smoke, /function waitForLegacyTimelineTypeSwitchRemoved/);


### PR DESCRIPTION
## Summary
- isolate kitchen-first QA on a separate date and valid working-day slot
- retry rendered timeline and cleanup snapshot checks after HTTP 429
- keep dual scenario/cleanup failure diagnostics visible

## Verification
- node --test tests/timeline-resources.test.js tests/timeline-browser-smoke-cleanup.test.js
- npm run check:timeline-protected-surface