### PR TITLE
Align production delivery policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,8 @@ Preferred workflow for normal product work:
 
 ## Deploy And Branch Boundaries
 
-- Last verified Railway production source branch (2026-07-13): `codex/performance-hardening`.
+- Last verified Railway production source branch (2026-07-20): `codex/production`.
+- Production deployment policy (2026-07-20): Railway GitHub auto-deploy is disabled for the production app service. Production deploy must be promoted manually only after the required GitHub CI checks are green for the exact release SHA.
 - Before every release or rollback, confirm the active Railway source branch read-only, push only to that confirmed branch, and pass it explicitly as `RELEASE_DEPLOY_BRANCH=<branch>` for release-proof/rollback notes.
 - Historical docs mention `codex/timeline-leads-hardening` and `deployed`; neither is the active deploy source unless the user explicitly says Railway was reconfigured.
 - Never upload files through the GitHub UI.

--- a/README.md
+++ b/README.md
@@ -234,12 +234,16 @@ If `package.json`, `index.html`, `CHANGELOG.md`, archived snapshots, standalone 
 
 ## Deploy And Branch Policy
 
-The last verified production source branch for Railway (2026-07-13) is
-`codex/performance-hardening`. Confirm the active Railway source branch before
+The last verified production source branch for Railway (2026-07-20) is
+`codex/production`. Confirm the active Railway source branch before
 every release or rollback because the attachment can change independently of
 the repository.
 
 - Do not deploy unless explicitly asked.
+- Railway GitHub auto-deploy is disabled for the production app service.
+  Production deploys must be promoted manually only after the required GitHub
+  CI checks are green for the exact release SHA. Deploy the exact validated SHA;
+  do not rely on an implicit local-directory upload for production release.
 - Push release/rollback commits only to the confirmed active Railway branch.
 - Always pass the confirmed branch explicitly as `RELEASE_DEPLOY_BRANCH=<branch>` for release proof notes; do not rely on a script fallback.
 - Treat `codex/timeline-leads-hardening` and `deployed` as historical deploy sources unless the owner explicitly confirms a Railway reconfiguration.

--- a/docs/BANQUET_PRODUCTION_RECOVERY.md
+++ b/docs/BANQUET_PRODUCTION_RECOVERY.md
@@ -148,6 +148,43 @@ Never put customer names, phone numbers, social handles, credentials, tokens,
 request headers, arbitrary API bodies, or browser form payloads into cleanup
 artifacts, terminal logs, tickets, commits, or release notes.
 
+### 1.5 Production acceptance evidence - 2026-07-20
+
+TASK 7 production acceptance was completed against:
+
+- Production URL: `https://8223324090-production.up.railway.app`;
+- version: `0.79.114`;
+- release label: `Безпечне закриття порожніх банкетних груп`;
+- release SHA: `c5469f4dbce80009c168d0edf59f6e32557fd1f6`;
+- source branch: `codex/production`.
+
+Acceptance scope:
+
+- `runId`: `task7-prod-1784545548168-3kwn2n`;
+- group ID: `BQ-MRT4C45S-24B1C1D0`;
+- booking ID count: `2`;
+- marker source: `timeline_browser_smoke`;
+- dependencies intentionally absent: deposits, receipts, certificates, stock
+  dependencies, payment references, and finance rows.
+
+Results:
+
+- marker-scoped dry-run returned `ready` with zero blockers;
+- exact booking set matched expected and actual sets;
+- first apply cancelled `2` bookings and `1` banquet group;
+- post-apply classification returned `already_cancelled_clean`;
+- repeated apply returned `already_cancelled_clean` with `0` cancelled bookings
+  and `0` cancelled groups;
+- live timeline API verification found `0` active rows for the disposable
+  booking set;
+- disposable customer cleanup through the standard customer endpoint succeeded;
+- read-only DB verification found bookings total `2`, active bookings `0`,
+  group total `1`, active groups `0`, finance rows `0`, deposit rows `0`,
+  disposable customer rows `0`, and cleanup history events `1`.
+
+This evidence intentionally omits customer PII, credentials, request headers,
+raw API payloads, and payment details.
+
 ## 2. Read-only recovery audit after deploy
 
 Use an explicit bounded date range:

--- a/docs/RELEASE_RELIABILITY.md
+++ b/docs/RELEASE_RELIABILITY.md
@@ -6,14 +6,23 @@
 
 ## Production Branch
 
-Остання фактично перевірена production-гілка Railway (13.07.2026):
-`codex/performance-hardening`.
+Остання фактично перевірена production-гілка Railway (20.07.2026):
+`codex/production`.
 
 Перед кожним release або rollback треба read-only перевіркою підтвердити активну
 Railway source branch і явно передати її в командах через
 `RELEASE_DEPLOY_BRANCH=<branch>`. Не покладатися на fallback у release-proof
 скрипті. `codex/timeline-leads-hardening` і `deployed` є історичними deploy
 sources, доки власник окремо не підтвердить переналаштування Railway.
+
+Production deploy policy з 20.07.2026: Railway GitHub auto-deploy вимкнений
+для production app service. Production deploy має запускатися вручну тільки
+після зелених required GitHub CI checks на точному release SHA. Деплоїти треба
+саме перевірений SHA, а не випадковий стан локальної директорії.
+
+Якщо Railway знову стартує deploy одразу після push і раніше завершення CI, це
+process drift: release не закривати як доставлений, доки CI не зелений і live
+version/health smoke не підтверджені.
 
 ## Production Branch Rule Exception
 

--- a/docs/TIMELINE_RELEASE_GUARDRAILS.md
+++ b/docs/TIMELINE_RELEASE_GUARDRAILS.md
@@ -26,12 +26,12 @@ npm run release:timeline-proof -- https://8223324090-production.up.railway.app
 ```
 
 Fallback release-proof скрипта синхронізований з останньою перевіреною
-production-гілкою станом на 13.07.2026 — `codex/performance-hardening`. Перед
+production-гілкою станом на 20.07.2026 — `codex/production`. Перед
 кожним release все одно підтвердь активну Railway source branch read-only
 перевіркою і передай її явно, тому що Railway attachment може змінитися:
 
 ```bash
-RELEASE_DEPLOY_BRANCH=codex/performance-hardening npm run release:timeline-proof -- <live-url>
+RELEASE_DEPLOY_BRANCH=codex/production npm run release:timeline-proof -- <live-url>
 ```
 
 Команда перевіряє:
@@ -65,7 +65,7 @@ npm run release:timeline-proof -- <live-url>
 1. Зафіксувати live branch target:
 
 ```bash
-RELEASE_DEPLOY_BRANCH=codex/performance-hardening
+RELEASE_DEPLOY_BRANCH=codex/production
 git ls-remote origin "$RELEASE_DEPLOY_BRANCH"
 ```
 

--- a/scripts/timeline-release-proof.js
+++ b/scripts/timeline-release-proof.js
@@ -57,7 +57,7 @@ function configuredDeployBranch() {
     return process.env.RELEASE_DEPLOY_BRANCH
         || process.env.RAILWAY_DEPLOY_BRANCH
         || process.env.DEPLOY_BRANCH
-        || 'codex/performance-hardening';
+        || 'codex/production';
 }
 
 function fail(message) {

--- a/tests/timeline-release-proof.test.js
+++ b/tests/timeline-release-proof.test.js
@@ -82,8 +82,8 @@ test('timeline release proof validates both shared contexts, assets, and service
         assert.ok(report.assets.some(item => item.path === 'js/booking-banquet-selector.js'));
         assert.ok(report.assets.some(item => item.path === 'js/booking-save-path.js'));
         assert.equal(report.serviceWorker.cacheName, `event-genix-v${pkg.version}`);
-        assert.equal(report.rollback.deployBranch, 'codex/performance-hardening');
-        assert.match(report.rollback.identifyLiveCommit, /codex\/performance-hardening/);
+        assert.equal(report.rollback.deployBranch, 'codex/production');
+        assert.match(report.rollback.identifyLiveCommit, /codex\/production/);
         assert.match(report.rollback.fallback, /git revert/);
         assert.doesNotMatch(report.rollback.fallback, /HEAD:deployed/);
     } finally {
@@ -111,7 +111,7 @@ test('timeline release guardrails are documented and exposed as a repo command',
     assert.equal(packageJson.scripts['release:timeline-proof'], 'node scripts/timeline-release-proof.js');
     assert.match(readme, /release:timeline-proof/);
     assert.match(docs, /npm run release:timeline-proof -- <live-url>/);
-    assert.match(docs, /RELEASE_DEPLOY_BRANCH=codex\/performance-hardening/);
+    assert.match(docs, /RELEASE_DEPLOY_BRANCH=codex\/production/);
     assert.match(docs, /git revert <bad-release-commit>/);
     assert.doesNotMatch(docs, /HEAD:deployed/);
 });


### PR DESCRIPTION
﻿## What changed
- Recorded the production acceptance evidence from the QA cleanup release.
- Updated current production branch documentation from `codex/performance-hardening` to `codex/production`.
- Documented the new production policy: Railway GitHub auto-deploy is disabled and production deploys must be manually promoted only after required GitHub CI passes for the exact SHA.
- Updated the timeline release-proof fallback and regression expectations to use `codex/production`.

## Why
Railway was actually deploying from `codex/production`, while current operating docs and fallback tooling still pointed at `codex/performance-hardening`. Railway also deployed immediately on push before CI completed, which was a production delivery process risk.

## Validation
- `npm ci`
- `npm run check:version`
- `node --check scripts/timeline-release-proof.js`
- `node --test tests/timeline-release-proof.test.js`
- `npm test` on the previous production head after these changes; after production advanced to v0.79.116, rechecked `npm run check:version`, `node --check scripts/timeline-release-proof.js`, and `node --test tests/timeline-release-proof.test.js`.
- Railway GraphQL `serviceInstanceAutoDeployUpdate(... enabled:false)` returned `enabled:false`.
- Read-only production `/api/version` and `/api/health` were checked after the policy change.

## Production notes
Auto-deploy was disabled for the production app service. No Railway deploy command was intentionally run by this PR. Parallel `codex/production` releases to v0.79.115 and v0.79.116 occurred during the policy change window and finished with green CI.
