### PR TITLE
Harden legacy permission compatibility

### DIFF
--- a/config/permissionRegistry.js
+++ b/config/permissionRegistry.js
@@ -129,6 +129,7 @@ function page(definition) {
         apiAccessCoupling: 'independent',
         status: PAGE_STATUS.ACTIVE,
         deprecated: false,
+        configurable: true,
         explicitAllow: true,
         replacementKey: null,
         notes: null,
@@ -153,11 +154,13 @@ function action(definition) {
         type: 'action',
         aliases: [],
         legacyKeys: [],
+        legacyDenyKeys: [],
         frontendConsumers: GENERIC_ACTION_FRONTEND,
         backendConsumers: GENERIC_ACTION_BACKEND,
         apiConsumers: [],
         status: ACTION_STATUS.ACTIVE,
         deprecated: false,
+        configurable: true,
         explicitAllow: true,
         replacementKey: null,
         notes: null,
@@ -166,6 +169,7 @@ function action(definition) {
         defaultRoles: Object.freeze([...(definition.defaultRoles || [])]),
         aliases: Object.freeze([...(definition.aliases || [])]),
         legacyKeys: Object.freeze([...(definition.legacyKeys || [])]),
+        legacyDenyKeys: Object.freeze([...(definition.legacyDenyKeys || [])]),
         frontendConsumers: Object.freeze([
             ...GENERIC_ACTION_FRONTEND,
             ...(definition.frontendConsumers || [])
@@ -181,7 +185,7 @@ function action(definition) {
 const PAGE_PERMISSIONS = Object.freeze([
     page({
         key: '/dashboard', label: 'Дашборд', group: 'today', canonicalPath: '/dashboard',
-        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT,
+        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT, configurable: false,
         sidebarLinks: ['/dashboard'], frontendConsumers: [source('dashboard.html', 'js/auth.js')],
         apiConsumers: [api('routes/dashboard.js', '/api/dashboard', null)],
         notes: 'Manual page toggle is redundant because every authenticated role is in the default role set.'
@@ -435,31 +439,31 @@ const PAGE_PERMISSIONS = Object.freeze([
     }),
     page({
         key: '/game', label: 'Гра', group: 'personal', canonicalPath: '/game',
-        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT,
+        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT, configurable: false,
         sidebarLinks: ['/game'], frontendConsumers: [source('game.html', 'js/auth.js')],
         apiConsumers: [api('routes/minigame.js', '/api/minigame', null), api('routes/gamification.js', '/api/gamification', null)]
     }),
     page({
         key: '/profile', label: 'Профіль', group: 'personal', canonicalPath: '/profile',
-        defaultRoles: ROLE_HIERARCHY, risk: 'medium', status: PAGE_STATUS.REDUNDANT,
+        defaultRoles: ROLE_HIERARCHY, risk: 'medium', status: PAGE_STATUS.REDUNDANT, configurable: false,
         frontendConsumers: [source('profile.html', 'js/auth.js')],
         apiConsumers: [api('routes/personal-accounts.js', '/api/personal-accounts', null, 'Bot API key and verified account-owner checks remain independent from page access.'), api('routes/achievements.js', '/api/achievements', null)]
     }),
     page({
         key: '/quiz', label: 'Квіз', group: 'personal', canonicalPath: '/quiz',
-        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT,
+        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT, configurable: false,
         frontendConsumers: [source('quiz.html', 'js/auth.js')],
         apiConsumers: [api('routes/quiz.js', '/api/quiz', null)]
     }),
     page({
         key: '/room', label: 'Кімната', group: 'personal', canonicalPath: '/room',
-        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT,
+        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT, configurable: false,
         frontendConsumers: [source('room.html', 'js/auth.js')],
         apiConsumers: [api('routes/room.js', '/api/room', null)]
     }),
     page({
         key: '/shop', label: 'Магазин', group: 'personal', canonicalPath: '/shop',
-        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT,
+        defaultRoles: ROLE_HIERARCHY, risk: 'low', status: PAGE_STATUS.REDUNDANT, configurable: false,
         frontendConsumers: [source('shop.html', 'js/auth.js')],
         apiConsumers: [api('routes/shop.js', '/api/shop', null)]
     })
@@ -656,9 +660,8 @@ const ACTION_PERMISSIONS = Object.freeze([
     }),
     action({
         key: 'cancel_booking', label: 'Скасовувати бронювання', group: 'bookings',
-        defaultRoles: MANAGER_UP, risk: 'high', status: ACTION_STATUS.DEAD, deprecated: true,
-        replacementKey: 'delete_booking',
-        notes: 'No endpoint or feature-specific frontend consumer enforces this action; cancellation uses other guards.'
+        defaultRoles: [], risk: 'high', status: ACTION_STATUS.DEAD, deprecated: true, configurable: false, explicitAllow: false,
+        notes: 'Compatibility tombstone. This legacy key is intentionally fail-closed and is not equivalent to delete_booking.'
     }),
     action({
         key: 'delete_booking', label: 'Видаляти бронювання', group: 'bookings',
@@ -668,7 +671,7 @@ const ACTION_PERMISSIONS = Object.freeze([
     }),
     action({
         key: 'manage_accounts', label: 'Керувати акаунтами', group: 'accounts',
-        defaultRoles: ['creator', 'director'], risk: 'critical', delegable: false,
+        defaultRoles: ['creator', 'director'], risk: 'critical', delegable: false, legacyDenyKeys: ['manage_users'],
         frontendConsumers: [source('js/hr-page.js', "canAccess('manage_accounts')", { enforces: true })],
         apiConsumers: [
             api('routes/users.js', '/api/users account lifecycle', 'manage_accounts'),
@@ -684,15 +687,13 @@ const ACTION_PERMISSIONS = Object.freeze([
     }),
     action({
         key: 'view_own', label: 'Бачити свої записи', group: 'record_scope',
-        defaultRoles: ['senior_instructor', 'instructor', 'animator', 'reception'], risk: 'high',
-        status: ACTION_STATUS.DEAD, deprecated: true,
-        notes: 'No feature-specific frontend or backend enforcement consumer was found.'
+        defaultRoles: [], risk: 'high', status: ACTION_STATUS.DEAD, deprecated: true, configurable: false, explicitAllow: false,
+        notes: 'Compatibility tombstone. Stored legacy values are ignored and cannot grant access.'
     }),
     action({
         key: 'manage_users', label: 'Керувати користувачами', group: 'accounts',
-        defaultRoles: ['creator', 'director'], risk: 'critical', delegable: false,
-        status: ACTION_STATUS.DEAD, deprecated: true, replacementKey: 'manage_accounts',
-        notes: 'Account endpoints use manage_accounts; this key remains in self-lockout invariants only.'
+        defaultRoles: [], risk: 'critical', delegable: false, status: ACTION_STATUS.DEAD, deprecated: true, configurable: false, explicitAllow: false,
+        notes: 'Compatibility tombstone. A stored deny remains a deny-alias for manage_accounts; a stored allow never grants it.'
     }),
     action({
         key: 'view_revenue', label: 'Бачити виручку', group: 'finance',
@@ -832,15 +833,33 @@ const ACTION_PERMISSIONS = Object.freeze([
     }),
     action({
         key: 'manage_staff', label: 'Керувати персоналом', group: 'hr',
-        defaultRoles: [...MANAGER_UP, 'hr', 'admin'], risk: 'critical',
-        frontendConsumers: [source('js/hr-page.js', "canAccess('manage_staff')", { enforces: true }), source('js/training-page.js', "canUseAction('manage_staff')", { enforces: true })],
-        backendConsumers: [source('routes/hermes-schedule.js', "canUseAction(req.user, 'manage_staff')", { enforces: true }), source('routes/training.js', "canUseAction(req.user, 'manage_staff')", { enforces: true })],
-        apiConsumers: [
-            api('routes/hr.js', '/api/hr management endpoints', null, 'Replaced by granular HR capabilities.'),
-            api('routes/staff.js', '/api/staff schedule and profile mutations', null, 'Schedule writes use hr.schedule.manage; profile writes use hr.staff.manage.'),
-            api('routes/hermes-schedule.js', '/api/hermes schedule mutations', null, 'Uses canUseAction instead of requireAction.'),
-            api('routes/training.js', '/api/training managed progress', null, 'Uses canUseAction instead of requireAction.')
+        defaultRoles: [], risk: 'critical', status: ACTION_STATUS.DEAD, deprecated: true, configurable: false, explicitAllow: false,
+        notes: 'Compatibility-only legacy key. Stored allow/deny values are interpreted by the granular capabilities that replaced its former consumers.'
+    }),
+    action({
+        key: 'hermes.staff.manage', label: 'Hermes: керування персоналом', group: 'hermes', defaultRoles: [...MANAGER_UP, 'hr', 'admin'], legacyKeys: ['manage_staff'], risk: 'critical',
+        backendConsumers: [
+            source('routes/users.js', "requireAction('hr.staff.manage')", { enforces: true }),
+            source('routes/hermes-schedule.js', "canUseAction(req.user, 'hermes.staff.manage')", { enforces: true }),
+            source('services/hermesStaffAccountOnboarding.js', "canUseAction(actor, 'hermes.staff.manage')", { enforces: true })
         ],
+        apiConsumers: [api('routes/users.js', '/api/users/onboarding', 'hr.staff.manage'), api('routes/hermes-schedule.js', 'POST /api/hermes/staff', null, 'Enforced by canUseAction granular capability'), api('routes/hermes.js', 'Hermes staff/account onboarding', null, 'Enforced by canUseAction granular capability')]
+    }),
+    action({
+        key: 'hermes.attendance.manage', label: 'Hermes: імпорт відвідуваності', group: 'hermes', defaultRoles: [...MANAGER_UP, 'hr', 'admin'], legacyKeys: ['manage_staff'], risk: 'critical',
+        backendConsumers: [source('routes/hermes-schedule.js', "canUseAction(req.user, 'hermes.attendance.manage')", { enforces: true })],
+        apiConsumers: [api('routes/hermes-schedule.js', '/api/hermes/attendance preview and apply', null, 'Enforced by canUseAction granular capability')]
+    }),
+    action({
+        key: 'hermes.schedule.manage', label: 'Hermes: керування графіком', group: 'hermes', defaultRoles: [...MANAGER_UP, 'hr', 'admin'], legacyKeys: ['manage_staff'], risk: 'critical',
+        backendConsumers: [source('routes/hermes-schedule.js', "canUseAction(req.user, 'hermes.schedule.manage')", { enforces: true })],
+        apiConsumers: [api('routes/hermes-schedule.js', '/api/hermes/staff-schedule preview and apply', null, 'Enforced by canUseAction granular capability')]
+    }),
+    action({
+        key: 'training.manage', label: 'Навчання: керування професійними чеклістами', group: 'training', defaultRoles: [...MANAGER_UP, 'hr', 'admin'], legacyKeys: ['manage_staff'], risk: 'critical',
+        backendConsumers: [source('routes/training.js', "canUseAction(req.user, 'training.manage')", { enforces: true })],
+        frontendConsumers: [source('js/training-page.js', "canUseAction('training.manage')", { enforces: true })],
+        apiConsumers: [api('routes/training.js', 'seeded profession checklist progress', null, 'Enforced by canUseAction granular capability')]
     }),
     action({
         key: 'view_payroll', label: 'Перегляд зарплати', group: 'payroll',
@@ -954,7 +973,7 @@ function canonicalizePageKey(value) {
  * those stay server-only.
  */
 function getPublicPagePermissionMetadata() {
-    return PAGE_PERMISSIONS.map(entry => ({
+    return PAGE_PERMISSIONS.filter(entry => entry.deprecated !== true && entry.configurable !== false).map(entry => ({
         key: entry.key,
         label: entry.label,
         group: entry.group,
@@ -965,6 +984,7 @@ function getPublicPagePermissionMetadata() {
         risk: entry.risk,
         status: entry.status,
         deprecated: entry.deprecated === true,
+        configurable: entry.configurable !== false,
         explicitAllow: entry.explicitAllow !== false
     }));
 }

--- a/js/auth.js
+++ b/js/auth.js
@@ -557,6 +557,7 @@ function clearRuntimePermissionCatalog(user) {
     PAGE_CAPABILITY_ALIASES = Object.create(null);
     ACTION_CAPABILITY_ALIASES = Object.create(null);
     ACTION_LEGACY_KEYS = Object.create(null);
+    ACTION_LEGACY_DENY_KEYS = Object.create(null);
     EXPLICIT_ALLOW_DISABLED_PAGES = new Set();
     EXPLICIT_ALLOW_DISABLED_ACTIONS = new Set();
     NON_DELEGABLE_ACTIONS = new Set();
@@ -571,6 +572,7 @@ function applyActionPermissions(user, permissions) {
     PAGE_CAPABILITY_ALIASES = catalog.pageAliases || Object.create(null);
     ACTION_CAPABILITY_ALIASES = catalog.actionAliases || Object.create(null);
     ACTION_LEGACY_KEYS = catalog.actionLegacyKeys || Object.create(null);
+    ACTION_LEGACY_DENY_KEYS = catalog.actionLegacyDenyKeys || Object.create(null);
     EXPLICIT_ALLOW_DISABLED_PAGES = new Set(catalog.explicitAllowDisabledPages || []);
     EXPLICIT_ALLOW_DISABLED_ACTIONS = new Set(catalog.explicitAllowDisabledActions || []);
     NON_DELEGABLE_ACTIONS = new Set(catalog.nonDelegableActions || []);
@@ -966,6 +968,7 @@ let ACTION_PERMISSIONS = Object.create(null);
 let PAGE_CAPABILITY_ALIASES = Object.create(null);
 let ACTION_CAPABILITY_ALIASES = Object.create(null);
 let ACTION_LEGACY_KEYS = Object.create(null);
+let ACTION_LEGACY_DENY_KEYS = Object.create(null);
 let EXPLICIT_ALLOW_DISABLED_PAGES = new Set();
 let EXPLICIT_ALLOW_DISABLED_ACTIONS = new Set();
 let NON_DELEGABLE_ACTIONS = new Set();
@@ -1615,7 +1618,9 @@ function resolveCapability(user, capability, context = {}) {
         ? getUserPageDenylist(effectiveUser)
         : getCurrentUserActionList('actionDenylist', 'action_denylist', effectiveUser);
     const overrideKeys = requestedType === 'action' ? [key, ...(ACTION_LEGACY_KEYS[key] || [])] : [key];
-    if (overrideKeys.some(candidate => denylist.includes(candidate))) {
+    const legacyDenyKeys = typeof ACTION_LEGACY_DENY_KEYS === 'undefined' ? [] : (ACTION_LEGACY_DENY_KEYS[key] || []);
+    const denyOverrideKeys = requestedType === 'action' ? [...overrideKeys, ...legacyDenyKeys] : overrideKeys;
+    if (denyOverrideKeys.some(candidate => denylist.includes(candidate))) {
         return _frontendCapabilityDecision(normalized, false, 'explicit_deny', null, 'listed_in_explicit_deny');
     }
 

--- a/js/hr-page.js
+++ b/js/hr-page.js
@@ -4322,7 +4322,7 @@ function normalizeProfessionTextList(value) {
 }
 
 function canEditProfessionCatalog() {
-    return typeof canAccess === 'function' && canAccess('manage_staff') === true;
+    return typeof canAccess === 'function' && canAccess('hr.staff.manage') === true;
 }
 
 function syncProfessionCatalogCapabilityUi() {
@@ -4863,7 +4863,7 @@ function professionWorkspaceStructureOptions(selected = '') {
 function canManageProfessionConditions(data = professionWorkspaceState.data) {
     const profession = data?.profession || {};
     if (profession.isReadonly === true || profession.is_readonly === true || profession.source === 'system') return false;
-    return typeof canAccess === 'function' && canAccess('manage_staff') === true;
+    return typeof canAccess === 'function' && canAccess('hr.staff.manage') === true;
 }
 
 function professionConditionSaveKey(professionKey, staffId) {
@@ -5063,7 +5063,7 @@ function renderProfessionWorkspacePeople(people = []) {
                 <fieldset><legend>Будні</legend><div class="hr-profession-condition-times"><label><span>Початок</span><input type="time" data-condition-weekday-start value="${escapeHtml(draft.weekdayStart)}"${timeDisabled}></label><label><span>Кінець</span><input type="time" data-condition-weekday-end value="${escapeHtml(draft.weekdayEnd)}"${timeDisabled}></label></div><small>${(draft.weekdaySource || weekdayPreference.source) === 'staff_shift_preferences' ? 'Збережено у staff_shift_preferences' : 'Системний fallback; буде записаний лише після явної зміни часу'}</small></fieldset>
                 <fieldset><legend>Вихідні</legend><div class="hr-profession-condition-times"><label><span>Початок</span><input type="time" data-condition-weekend-start value="${escapeHtml(draft.weekendStart)}"${timeDisabled}></label><label><span>Кінець</span><input type="time" data-condition-weekend-end value="${escapeHtml(draft.weekendEnd)}"${timeDisabled}></label></div><small>${(draft.weekendSource || weekendPreference.source) === 'staff_shift_preferences' ? 'Збережено у staff_shift_preferences' : 'Системний fallback; буде записаний лише після явної зміни часу'}</small></fieldset>
             </div>
-            <footer><span data-condition-feedback role="status">${escapeHtml(feedback || (!editable ? 'Лише перегляд: потрібна capability manage_staff' : ''))}</span>${editable ? `<button type="button" class="btn-add" data-condition-save${['changed', 'error'].includes(rowState.status) && !saving ? '' : ' disabled'}>Зберегти рядок</button>` : ''}</footer>
+            <footer><span data-condition-feedback role="status">${escapeHtml(feedback || (!editable ? 'Лише перегляд: потрібна capability hr.staff.manage' : ''))}</span>${editable ? `<button type="button" class="btn-add" data-condition-save${['changed', 'error'].includes(rowState.status) && !saving ? '' : ' disabled'}>Зберегти рядок</button>` : ''}</footer>
         </article>`;
     }).join('');
 }
@@ -5714,7 +5714,7 @@ let accountOnboardingState = {
 const ACCOUNT_SECURITY_ROLES = ['creator', 'director'];
 const ACCOUNT_PROFILE_ROLES = ['creator', 'director'];
 const ACCOUNT_NON_DELEGABLE_ACTIONS = new Set(['manage_accounts', 'manage_settings']);
-const ACCOUNT_DEPRECATED_ACTIONS = new Set(['cancel_booking', 'view_own', 'manage_users']);
+const ACCOUNT_DEPRECATED_ACTIONS = new Set(['cancel_booking', 'view_own', 'manage_users', 'manage_staff']);
 const ACCOUNT_BUSINESS_SWITCH_ROLES = new Set(['creator', 'director']);
 const ACCOUNT_ROLE_PRESET_LABELS = {
     executive: 'Керівництво',
@@ -5763,7 +5763,7 @@ function canManageAccountSecurity() {
 }
 
 function canRunAccountOnboarding() {
-    const canManageStaff = typeof canAccess === 'function' ? canAccess('manage_staff') : false;
+    const canManageStaff = typeof canAccess === 'function' ? canAccess('hr.staff.manage') : false;
     return canManageAccountSecurity() && canManageStaff;
 }
 
@@ -7404,7 +7404,7 @@ async function loadAccountCenter(options = {}) {
     if (createBtn) createBtn.classList.toggle('hidden', !canOnboard);
     if (adminNote) {
         adminNote.textContent = canManageSecurity
-            ? 'Створення акаунта разом із HR-профілем потребує capability manage_accounts і manage_staff.'
+            ? 'Створення акаунта разом із HR-профілем потребує capability manage_accounts і hr.staff.manage.'
             : 'Для керування акаунтами потрібна capability manage_accounts.';
         adminNote.classList.toggle('hidden', canOnboard);
     }
@@ -8685,7 +8685,7 @@ function bindAccountOnboardingControls() {
 
 async function openAccountOnboardingWizard(button, context = {}) {
     if (!canRunAccountOnboarding()) {
-        showNotification('Для контрольованого onboarding потрібні capability manage_accounts і manage_staff', 'error');
+        showNotification('Для контрольованого onboarding потрібні capability manage_accounts і hr.staff.manage', 'error');
         return false;
     }
     const overlay = accountOnboardingEl('accountOnboardingOverlay');
@@ -13495,7 +13495,7 @@ const COMPANY_ORG_ARCHIVE_FILTERS = new Set(['active', 'archived', 'all']);
 
 function canEditCompanyStructure() {
     if (companyStructurePermissionDenied) return false;
-    return typeof canAccess === 'function' && canAccess('manage_staff') === true;
+    return typeof canAccess === 'function' && canAccess('hr.staff.manage') === true;
 }
 
 function companyStructureHasUnsavedChanges() {
@@ -13620,7 +13620,7 @@ function renderCompanyStructureEditorState() {
     } else if (companyStructureLoadState === 'empty' && !companyStructureHasSavedData) {
         recoveryText = editable
             ? 'Сервер підтвердив, що збереженої структури немає. Базовий шаблон буде застосовано лише після вашого підтвердження.'
-            : 'Збереженої структури ще немає. Створити її може користувач із правом manage_staff.';
+            : 'Збереженої структури ще немає. Створити її може користувач із правом hr.staff.manage.';
         if (editable) templateButton?.classList.remove('hidden');
     } else if (companyStructureSaveState === 'conflict') {
         const current = companyStructureConflictCurrent || {};
@@ -15147,7 +15147,7 @@ function updateCompanyOrgLinkStatus() {
     const status = document.getElementById('hrOrgLinkStatus');
     if (status) {
         if (!canEditCompanyStructure()) {
-            status.textContent = 'Режим лише для перегляду. Змінювати підпорядкування може користувач із manage_staff.';
+            status.textContent = 'Режим лише для перегляду. Змінювати підпорядкування може користувач із hr.staff.manage.';
             status.classList.remove('is-active');
         } else if (companyStructureLoadState !== 'ready') {
             status.textContent = 'Редагування стане доступним після завантаження актуальної структури.';

--- a/js/training-page.js
+++ b/js/training-page.js
@@ -193,8 +193,8 @@
     }
 
     function canManageOnboarding() {
-        if (typeof canUseAction === 'function') return canUseAction('manage_staff');
-        return typeof canAccess === 'function' && canAccess('manage_staff');
+        if (typeof canUseAction === 'function') return canUseAction('training.manage');
+        return typeof canAccess === 'function' && canAccess('training.manage');
     }
 
     function updateOnboardingAccess() {

--- a/routes/hermes-schedule.js
+++ b/routes/hermes-schedule.js
@@ -488,12 +488,12 @@ function createHermesScheduleRouter(options = {}) {
         requireHermesScheduleAccess,
         applyMutationGuard,
         (req, res, next) => {
-            if (!canUseAction(req.user, 'manage_staff')) {
+            if (!canUseAction(req.user, 'hermes.staff.manage')) {
                 return sendHermesScheduleError(
                     res,
                     403,
-                    'HERMES_MANAGE_STAFF_REQUIRED',
-                    'Hermes actor does not have manage_staff permission'
+                    'HERMES_CAPABILITY_REQUIRED',
+                    'Hermes actor does not have the required granular capability'
                 );
             }
             return next();
@@ -704,12 +704,12 @@ function createHermesScheduleRouter(options = {}) {
         '/attendance/preview',
         requireHermesScheduleAccess,
         (req, res, next) => {
-            if (!canUseAction(req.user, 'manage_staff')) {
+            if (!canUseAction(req.user, 'hermes.attendance.manage')) {
                 return sendHermesScheduleError(
                     res,
                     403,
-                    'HERMES_MANAGE_STAFF_REQUIRED',
-                    'Hermes actor does not have manage_staff permission'
+                    'HERMES_CAPABILITY_REQUIRED',
+                    'Hermes actor does not have the required granular capability'
                 );
             }
             return next();
@@ -747,12 +747,12 @@ function createHermesScheduleRouter(options = {}) {
         requireHermesScheduleAccess,
         applyMutationGuard,
         (req, res, next) => {
-            if (!canUseAction(req.user, 'manage_staff')) {
+            if (!canUseAction(req.user, 'hermes.attendance.manage')) {
                 return sendHermesScheduleError(
                     res,
                     403,
-                    'HERMES_MANAGE_STAFF_REQUIRED',
-                    'Hermes actor does not have manage_staff permission'
+                    'HERMES_CAPABILITY_REQUIRED',
+                    'Hermes actor does not have the required granular capability'
                 );
             }
             return next();
@@ -813,7 +813,12 @@ function createHermesScheduleRouter(options = {}) {
         }
     );
 
-    router.post('/staff-schedule/preview', requireHermesScheduleAccess, async (req, res) => {
+    router.post('/staff-schedule/preview', requireHermesScheduleAccess, (req, res, next) => {
+        if (!canUseAction(req.user, 'hermes.schedule.manage')) {
+            return sendHermesScheduleError(res, 403, 'HERMES_CAPABILITY_REQUIRED', 'Hermes actor does not have the required granular capability');
+        }
+        return next();
+    }, async (req, res) => {
         try {
             const preview = await previewHermesScheduleImport(db, req.body || {}, {
                 actorUserId: req.integration?.actorUserId || req.user?.id,
@@ -839,12 +844,12 @@ function createHermesScheduleRouter(options = {}) {
         requireHermesScheduleAccess,
         applyMutationGuard,
         (req, res, next) => {
-            if (!canUseAction(req.user, 'manage_staff')) {
+            if (!canUseAction(req.user, 'hermes.schedule.manage')) {
                 return sendHermesScheduleError(
                     res,
                     403,
-                    'HERMES_MANAGE_STAFF_REQUIRED',
-                    'Hermes actor does not have manage_staff permission'
+                    'HERMES_CAPABILITY_REQUIRED',
+                    'Hermes actor does not have the required granular capability'
                 );
             }
             return next();

--- a/routes/hermes.js
+++ b/routes/hermes.js
@@ -2007,7 +2007,7 @@ function buildCapabilitiesPayload(env = process.env) {
                 defaultIncludeFreelance: false,
                 createRequiresConfirmation: true,
                 createRequiresIdempotencyKey: true,
-                createRequiresManageStaff: true,
+                createRequiredCapability: 'hermes.staff.manage',
                 createScheduleWrites: 0
             },
             staffAccountOnboarding: {
@@ -2024,7 +2024,7 @@ function buildCapabilitiesPayload(env = process.env) {
                 createRequestAccountWrites: 0,
                 approveRequiresConfirmation: true,
                 approveRequiresIdempotencyKey: true,
-                approveRequiresManageStaff: true,
+                approveRequiredStaffCapability: 'hermes.staff.manage',
                 approveRequiresManageAccounts: true,
                 rejectRequiresConfirmation: true,
                 rejectRequiresIdempotencyKey: true,
@@ -2047,7 +2047,7 @@ function buildCapabilitiesPayload(env = process.env) {
                 previewScheduleWrites: 0,
                 applyRequiresConfirmation: true,
                 applyRequiresIdempotencyKey: true,
-                applyRequiresManageStaff: true
+                applyRequiredCapability: 'hermes.schedule.manage'
             },
             attendance: {
                 preview: 'POST /api/hermes/attendance/preview',
@@ -2055,13 +2055,13 @@ function buildCapabilitiesPayload(env = process.env) {
                 businessContext: 'event_genix',
                 maxPreviewRows: 100,
                 previewTtlMinutes: 30,
-                previewRequiresManageStaff: true,
+                previewRequiredCapability: 'hermes.attendance.manage',
                 previewAttendanceWrites: 0,
                 previewScheduleWrites: 0,
                 scheduleWrites: 0,
                 applyRequiresConfirmation: true,
                 applyRequiresIdempotencyKey: true,
-                applyRequiresManageStaff: true,
+                applyRequiredCapability: 'hermes.attendance.manage',
                 applyScheduleWrites: 0
             }
         },
@@ -2080,14 +2080,14 @@ function buildCapabilitiesPayload(env = process.env) {
 }
 
 function assertHermesStaffAccountOnboardingAccess(req, res) {
-    if (canUseAction(req.user, 'manage_staff') && canUseAction(req.user, 'manage_accounts')) {
+    if (canUseAction(req.user, 'hermes.staff.manage') && canUseAction(req.user, 'manage_accounts')) {
         return true;
     }
     sendHermesError(
         res,
         403,
         'HERMES_STAFF_ACCOUNT_ONBOARDING_ACTION_FORBIDDEN',
-        'Hermes staff/account onboarding requires manage_staff and manage_accounts'
+        'Hermes staff/account onboarding requires hermes.staff.manage and manage_accounts'
     );
     return false;
 }

--- a/routes/training.js
+++ b/routes/training.js
@@ -897,7 +897,7 @@ router.get('/courses', async (req, res) => {
             )
         ]);
         const metricsByCourse = new Map(metricResult.rows.map(row => [Number(row.course_id), row]));
-        const canManageSeedProgress = canUseAction(req.user, 'manage_staff');
+        const canManageSeedProgress = canUseAction(req.user, 'training.manage');
         const courses = courseResult.rows.map(row => {
             const metrics = metricsByCourse.get(Number(row.id)) || {};
             if (isProfessionSeedCourse(row)) {
@@ -981,7 +981,7 @@ router.get('/courses/:id', async (req, res) => {
                     progress_mode: 'canonical_checklist',
                     canonical_staff_id: linkedProfile.staffId,
                     canonical_staff_link_status: linkedProfile.status,
-                    can_complete: canUseAction(req.user, 'manage_staff')
+                    can_complete: canUseAction(req.user, 'training.manage')
                         && linkedProfile.status === 'linked'
                         && linkedProfile.staff?.isActive !== false
                 },
@@ -1145,7 +1145,7 @@ router.post('/courses/:courseId/lectures/:lectureId/complete', async (req, res) 
             throw trainingCourseRequestError('Курс неактивний', 409, 'TRAINING_COURSE_INACTIVE');
         }
         const seededCourse = isProfessionSeedCourse(course);
-        if (seededCourse && !canUseAction(req.user, 'manage_staff')) {
+        if (seededCourse && !canUseAction(req.user, 'training.manage')) {
             throw trainingCourseRequestError(
                 'Професійний чекліст доступний лише для перегляду',
                 403,

--- a/routes/users.js
+++ b/routes/users.js
@@ -207,26 +207,29 @@ function accountActionDenylist(account = {}) {
 }
 
 function normalizePageDenylistInput(value, options = {}) {
-    return normalizeCapabilityList(value, CAPABILITY_TYPES.PAGE, options).values;
+    return normalizeCapabilityList(value, CAPABILITY_TYPES.PAGE, { ...options, excludeNonConfigurable: true }).values;
 }
 
 function normalizeActionAllowlist(value, options = {}) {
     return normalizeCapabilityList(value, CAPABILITY_TYPES.ACTION, {
         ...options,
         excludeNonDelegable: true,
-        excludeExplicitAllowDisabled: true
+        excludeExplicitAllowDisabled: true,
+        excludeDeprecated: true
     }).values;
 }
 
 function normalizePageAllowlistInput(value, options = {}) {
     return normalizeCapabilityList(value, CAPABILITY_TYPES.PAGE, {
         ...options,
-        excludeExplicitAllowDisabled: true
+        excludeExplicitAllowDisabled: true,
+        excludeDeprecated: true,
+        excludeNonConfigurable: true
     }).values;
 }
 
 function normalizePageAllowlistUpdateInput(value, options = {}) {
-    return normalizeCapabilityList(value, CAPABILITY_TYPES.PAGE, options).values;
+    return normalizeCapabilityList(value, CAPABILITY_TYPES.PAGE, { ...options, excludeNonConfigurable: true }).values;
 }
 
 function assertNoNewExplicitAllowDisabledPages(requestedAllowlist, currentAllowlist, fieldName = 'pageAllowlist') {
@@ -244,7 +247,7 @@ function assertNoNewExplicitAllowDisabledPages(requestedAllowlist, currentAllowl
 
 function assertSelfAccountAccessSafe(actor, prospectiveAccount) {
     if (!actor || !prospectiveAccount || Number(actor.id) !== Number(prospectiveAccount.id)) return;
-    if (!canUseAction(prospectiveAccount, 'manage_accounts') || !canUseAction(prospectiveAccount, 'manage_users')) {
+    if (!canUseAction(prospectiveAccount, 'manage_accounts')) {
         const err = new Error('Не можна забрати в себе доступ до керування акаунтами');
         err.statusCode = 400;
         throw err;
@@ -465,7 +468,7 @@ router.get('/link-conflicts', requireAction('manage_accounts'), async (req, res)
 });
 
 // GET /api/users/onboarding/options — aggregate data for the controlled account onboarding wizard
-router.get('/onboarding/options', requireAction('manage_accounts'), requireAction('manage_staff'), async (req, res) => {
+router.get('/onboarding/options', requireAction('manage_accounts'), requireAction('hr.staff.manage'), async (req, res) => {
     try {
         const [staffResult, professionResult, structureResult, conditionResult] = await Promise.all([
             pool.query(
@@ -585,7 +588,7 @@ router.get('/onboarding/options', requireAction('manage_accounts'), requireActio
 });
 
 // POST /api/users/onboarding — atomically create/link account and HR working setup
-router.post('/onboarding', requireAction('manage_accounts'), requireAction('manage_staff'), async (req, res) => {
+router.post('/onboarding', requireAction('manage_accounts'), requireAction('hr.staff.manage'), async (req, res) => {
     try {
         const result = await createAccountOnboarding({
             payload: req.body || {},
@@ -872,7 +875,7 @@ async function updateAccountAccess(req, res) {
             ? normalizeActionAllowlist(actionAllowlistInput, { strict: true, fieldName: 'actionAllowlist' })
             : null;
         const normalizedActionDenylist = actionDenylistInput !== undefined
-            ? normalizeActionOverrideList(actionDenylistInput, { strict: true, fieldName: 'actionDenylist' })
+            ? normalizeActionOverrideList(actionDenylistInput, { strict: true, fieldName: 'actionDenylist', excludeDeprecated: true })
             : null;
 
         client = await pool.connect();
@@ -1268,7 +1271,7 @@ router.post('/', requireAction('manage_accounts'), async (req, res) => {
             ? normalizeActionAllowlist(actionAllowlistInput, { strict: true, fieldName: 'actionAllowlist' })
             : [];
         const normalizedActionDenylist = actionDenylistInput !== undefined
-            ? normalizeActionOverrideList(actionDenylistInput, { strict: true, fieldName: 'actionDenylist' })
+            ? normalizeActionOverrideList(actionDenylistInput, { strict: true, fieldName: 'actionDenylist', excludeDeprecated: true })
             : [];
         assertNoCapabilityConflicts(normalizedPageAllowlist, normalizedPageDenylist, CAPABILITY_TYPES.PAGE);
         assertNoCapabilityConflicts(normalizedActionAllowlist, normalizedActionDenylist);

--- a/services/accountAccessPolicy.js
+++ b/services/accountAccessPolicy.js
@@ -18,11 +18,14 @@ const CAPABILITY_TYPES = Object.freeze({
 const PAGE_ACCESS = Object.freeze(Object.fromEntries(
     PAGE_PERMISSIONS.map(entry => [entry.key, entry.defaultRoles])
 ));
+const ACTIVE_ACTION_PERMISSION_ENTRIES = Object.freeze(
+    ACTION_PERMISSION_ENTRIES.filter(entry => entry.deprecated !== true)
+);
 const ACTION_PERMISSIONS = Object.freeze(Object.fromEntries(
-    ACTION_PERMISSION_ENTRIES.map(entry => [entry.key, entry.defaultRoles])
+    ACTIVE_ACTION_PERMISSION_ENTRIES.map(entry => [entry.key, entry.defaultRoles])
 ));
 const NON_DELEGABLE_ACTIONS = new Set(
-    ACTION_PERMISSION_ENTRIES.filter(entry => entry.delegable === false).map(entry => entry.key)
+    ACTIVE_ACTION_PERMISSION_ENTRIES.filter(entry => entry.delegable === false).map(entry => entry.key)
 );
 const ACTION_ALIAS_TO_CANONICAL = Object.freeze(ACTION_PERMISSION_ENTRIES.reduce((result, entry) => {
     entry.aliases.forEach(alias => { result[alias] = entry.key; });
@@ -114,11 +117,21 @@ function normalizeCapabilityList(value, type, options = {}) {
     const unknownKeys = [];
     const nonDelegableKeys = [];
     const explicitAllowDisabledKeys = [];
+    const deprecatedKeys = [];
+    const nonConfigurableKeys = [];
 
     for (const rawKey of normalizeRawList(value)) {
         const normalized = normalizeCapability(rawKey, { type });
         if (!normalized.known) {
             unknownKeys.push(rawKey);
+            continue;
+        }
+        if (options.excludeDeprecated === true && normalized.definition.deprecated === true) {
+            deprecatedKeys.push(normalized.key);
+            continue;
+        }
+        if (options.excludeNonConfigurable === true && normalized.definition.configurable === false) {
+            nonConfigurableKeys.push(normalized.key);
             continue;
         }
         if (options.excludeNonDelegable === true
@@ -152,7 +165,25 @@ function normalizeCapabilityList(value, type, options = {}) {
         );
     }
 
-    return { values: result, unknownKeys, nonDelegableKeys, explicitAllowDisabledKeys };
+    if (options.strict === true && deprecatedKeys.length) {
+        const fieldName = options.fieldName || `${type} capabilities`;
+        throw new CapabilityValidationError(
+            `${fieldName} contains deprecated permission keys: ${deprecatedKeys.join(', ')}`,
+            'DEPRECATED_CAPABILITY_KEYS',
+            { field: fieldName, deprecatedKeys }
+        );
+    }
+
+    if (options.strict === true && nonConfigurableKeys.length) {
+        const fieldName = options.fieldName || `${type} capabilities`;
+        throw new CapabilityValidationError(
+            `${fieldName} contains non-configurable permission keys: ${nonConfigurableKeys.join(', ')}`,
+            'NON_CONFIGURABLE_CAPABILITY_KEYS',
+            { field: fieldName, nonConfigurableKeys }
+        );
+    }
+
+    return { values: result, unknownKeys, nonDelegableKeys, explicitAllowDisabledKeys, deprecatedKeys, nonConfigurableKeys };
 }
 
 function normalizePageAllowlist(userOrValue) {
@@ -222,7 +253,7 @@ function resolveCapability(user, capability, context = {}) {
     if (!user) {
         return decision(normalized, false, 'default_deny', null, 'user_missing');
     }
-    if (!normalized.known) {
+    if (!normalized.known || (normalized.type === CAPABILITY_TYPES.ACTION && normalized.definition.deprecated === true)) {
         return decision(normalized, false, 'default_deny', null, 'unknown_capability');
     }
 
@@ -230,7 +261,10 @@ function resolveCapability(user, capability, context = {}) {
     const overrideKeys = normalized.type === CAPABILITY_TYPES.ACTION
         ? [normalized.key, ...(normalized.definition.legacyKeys || [])]
         : [normalized.key];
-    if (overrideKeys.some(key => lists.deny.includes(key))) {
+    const denyOverrideKeys = normalized.type === CAPABILITY_TYPES.ACTION
+        ? [...overrideKeys, ...(normalized.definition.legacyDenyKeys || [])]
+        : overrideKeys;
+    if (denyOverrideKeys.some(key => lists.deny.includes(key))) {
         return decision(normalized, false, 'explicit_deny', null, 'listed_in_explicit_deny');
     }
 
@@ -265,9 +299,10 @@ function buildCapabilityCatalog() {
         actionRoles: ACTION_PERMISSIONS,
         pageAliases: PAGE_ALIAS_TO_CANONICAL,
         actionAliases: ACTION_ALIAS_TO_CANONICAL,
-        actionLegacyKeys: Object.freeze(Object.fromEntries(ACTION_PERMISSION_ENTRIES.map(entry => [entry.key, entry.legacyKeys || []]))),
+        actionLegacyKeys: Object.freeze(Object.fromEntries(ACTIVE_ACTION_PERMISSION_ENTRIES.map(entry => [entry.key, entry.legacyKeys || []]))),
+        actionLegacyDenyKeys: Object.freeze(Object.fromEntries(ACTIVE_ACTION_PERMISSION_ENTRIES.map(entry => [entry.key, entry.legacyDenyKeys || []]))),
         explicitAllowDisabledPages: Object.freeze(PAGE_PERMISSIONS.filter(entry => entry.explicitAllow === false).map(entry => entry.key)),
-        explicitAllowDisabledActions: Object.freeze(ACTION_PERMISSION_ENTRIES.filter(entry => entry.explicitAllow === false).map(entry => entry.key)),
+        explicitAllowDisabledActions: Object.freeze(ACTIVE_ACTION_PERMISSION_ENTRIES.filter(entry => entry.explicitAllow === false).map(entry => entry.key)),
         nonDelegableActions: Object.freeze(Array.from(NON_DELEGABLE_ACTIONS))
     });
 }
@@ -282,7 +317,7 @@ function buildCapabilitySnapshot(user, context = {}) {
         pages[entry.key] = resolved.allowed;
         decisions[resolved.capability] = resolved;
     }
-    for (const entry of ACTION_PERMISSION_ENTRIES) {
+    for (const entry of ACTIVE_ACTION_PERMISSION_ENTRIES) {
         const resolved = resolveCapability(user, entry.key, { ...context, type: CAPABILITY_TYPES.ACTION });
         actions[entry.key] = resolved.allowed;
         decisions[resolved.capability] = resolved;

--- a/services/hermesStaffAccountOnboarding.js
+++ b/services/hermesStaffAccountOnboarding.js
@@ -95,9 +95,9 @@ function normalizeBusinessContext(value) {
 }
 
 function requireStaffAccountOnboardingActor(actor = {}) {
-    if (!canUseAction(actor, 'manage_staff') || !canUseAction(actor, 'manage_accounts')) {
+    if (!canUseAction(actor, 'hermes.staff.manage') || !canUseAction(actor, 'manage_accounts')) {
         throw onboardingFlowError(
-            'Hermes actor needs manage_staff and manage_accounts for staff/account onboarding',
+            'Hermes actor needs hermes.staff.manage and manage_accounts for staff/account onboarding',
             403,
             'HERMES_STAFF_ACCOUNT_ONBOARDING_ACTION_FORBIDDEN'
         );

--- a/tests/account-access-policy.test.js
+++ b/tests/account-access-policy.test.js
@@ -179,6 +179,53 @@ test('capability snapshot preserves compatibility maps and structured decisions'
     assert.ok(snapshot.catalog.nonDelegableActions.includes('fiscal.configure'));
     assert.ok(snapshot.catalog.explicitAllowDisabledPages.includes('/finance'));
     assert.ok(snapshot.catalog.explicitAllowDisabledActions.includes('finance.manage'));
+    assert.equal(snapshot.catalog.actionLegacyKeys['training.manage'].includes('manage_staff'), true);
+    assert.equal(snapshot.catalog.actionLegacyDenyKeys.manage_accounts.includes('manage_users'), true);
+});
+
+test('legacy stored action states stay compatible without exposing dead toggles', () => {
+    assert.equal(resolveCapability({ role: 'manager', action_allowlist: ['cancel_booking'] }, 'cancel_booking').allowed, false);
+    assert.equal(resolveCapability({ role: 'manager', action_denylist: ['cancel_booking'] }, 'cancel_booking').allowed, false);
+    assert.equal(resolveCapability({ role: 'animator', action_allowlist: ['view_own'] }, 'view_own').allowed, false);
+    assert.equal(resolveCapability({ role: 'animator', action_allowlist: ['manage_users'] }, 'manage_accounts').allowed, false);
+    assert.equal(resolveCapability({ role: 'director', action_denylist: ['manage_users'] }, 'manage_accounts').allowed, false);
+
+    const legacyStaffAllow = { role: 'animator', action_allowlist: ['manage_staff'] };
+    assert.equal(resolveCapability(legacyStaffAllow, 'training.manage').allowed, true);
+    assert.equal(resolveCapability(legacyStaffAllow, 'hermes.staff.manage').allowed, true);
+    assert.equal(resolveCapability(legacyStaffAllow, 'manage_staff').allowed, false);
+
+    const legacyStaffDeny = { role: 'manager', action_denylist: ['manage_staff'] };
+    assert.equal(resolveCapability(legacyStaffDeny, 'training.manage').allowed, false);
+    assert.equal(resolveCapability(legacyStaffDeny, 'hermes.schedule.manage').allowed, false);
+});
+
+test('strict account writes reject deprecated actions and non-configurable page toggles', () => {
+    for (const key of ['cancel_booking', 'view_own', 'manage_users', 'manage_staff']) {
+        assert.throws(
+            () => normalizeCapabilityList([key], 'action', {
+                strict: true,
+                excludeDeprecated: true,
+                fieldName: 'actionAllowlist'
+            }),
+            error => error instanceof CapabilityValidationError
+                && error.code === 'DEPRECATED_CAPABILITY_KEYS'
+                && error.details.deprecatedKeys.includes(key)
+        );
+    }
+
+    for (const key of ['/dashboard', '/profile', '/game', '/quiz', '/room', '/shop']) {
+        assert.throws(
+            () => normalizeCapabilityList([key], 'page', {
+                strict: true,
+                excludeNonConfigurable: true,
+                fieldName: 'pageAllowlist'
+            }),
+            error => error instanceof CapabilityValidationError
+                && error.code === 'NON_CONFIGURABLE_CAPABILITY_KEYS'
+                && error.details.nonConfigurableKeys.includes(key)
+        );
+    }
 });
 
 test('Finance explicit grants are rejected by strict account-access writes', () => {

--- a/tests/account-center-contract.test.js
+++ b/tests/account-center-contract.test.js
@@ -93,8 +93,8 @@ test('account creation uses the seven-step atomic onboarding workspace', () => {
     assert.match(HR_PAGE_CODE, /crmApiFetch\('\/api\/users\/onboarding\/options'\)/);
     assert.match(HR_PAGE_CODE, /crmApiFetch\('\/api\/users\/onboarding'/);
     assert.match(HR_PAGE_CODE, /rateMode !== 'keep'/);
-    assert.match(USERS_ROUTE, /router\.post\('\/onboarding', requireAction\('manage_accounts'\), requireAction\('manage_staff'\)/);
-    assert.match(USERS_ROUTE, /router\.get\('\/onboarding\/options', requireAction\('manage_accounts'\), requireAction\('manage_staff'\)/);
+    assert.match(USERS_ROUTE, /router\.post\('\/onboarding', requireAction\('manage_accounts'\), requireAction\('hr\.staff\.manage'\)/);
+    assert.match(USERS_ROUTE, /router\.get\('\/onboarding\/options', requireAction\('manage_accounts'\), requireAction\('hr\.staff\.manage'\)/);
     assert.match(HR_PAGE_CODE, /function canRunAccountOnboarding/);
     assert.match(HR_HTML, /option value="unchanged"/);
     assert.match(HR_PAGE_CODE, /expectedRequestSeq !== accountOnboardingRequestSeq/);

--- a/tests/auth-account-lifecycle.test.js
+++ b/tests/auth-account-lifecycle.test.js
@@ -665,10 +665,10 @@ test('impersonation honors manage_accounts denylist, blocks self, and preserves 
     });
 });
 
-test('account onboarding requires manage_staff in addition to manage_accounts before any transaction', async () => {
+test('account onboarding requires hr.staff.manage in addition to manage_accounts before any transaction', async () => {
     await withAuthApp(async ({ baseUrl, fakePool }) => {
         const creator = fakePool.state.users[0];
-        creator.action_denylist = ['manage_staff'];
+        creator.action_denylist = ['hr.staff.manage'];
 
         const options = await request(baseUrl, 'GET', '/api/users/onboarding/options', undefined, creatorToken());
         const create = await request(baseUrl, 'POST', '/api/users/onboarding', {}, creatorToken());
@@ -1116,7 +1116,7 @@ test('account action overrides drive final permissions and protect against self-
 
         const creatorRolesMatrix = await request(baseUrl, 'GET', '/api/users/roles', undefined, creatorToken());
         assert.equal(creatorRolesMatrix.status, 200);
-        assert.deepEqual(creatorRolesMatrix.data.nonDelegableActions.sort(), ['fiscal.configure', 'manage_accounts', 'manage_settings', 'manage_users'].sort());
+        assert.deepEqual(creatorRolesMatrix.data.nonDelegableActions.sort(), ['fiscal.configure', 'manage_accounts', 'manage_settings'].sort());
         assert.equal(creatorRolesMatrix.data.actions.find(action => action.key === 'manage_accounts').delegable, false);
 
         const createArtDirector = await request(baseUrl, 'POST', '/api/users', {
@@ -1198,10 +1198,10 @@ test('director account management is capped below director level', async () => {
             password: 'ManagerPass789!',
             name: 'Manager By Director',
             role: 'manager',
-            actionAllowlist: ['delete_booking', 'manage_staff', 'manage_accounts']
+            actionAllowlist: ['delete_booking', 'hr.staff.manage', 'manage_accounts']
         }, directorToken);
         assert.equal(createManager.status, 200, JSON.stringify(createManager.data));
-        assert.deepEqual(createManager.data.user.action_allowlist, ['delete_booking', 'manage_staff']);
+        assert.deepEqual(createManager.data.user.action_allowlist, ['delete_booking', 'hr.staff.manage']);
 
         const createPeerDirector = await request(baseUrl, 'POST', '/api/users', {
             username: 'peer.director',

--- a/tests/browser/hr-structure-tree-browser-smoke.js
+++ b/tests/browser/hr-structure-tree-browser-smoke.js
@@ -82,7 +82,7 @@ async function installHarness(page, width = 1280, theme = 'light') {
     await page.setContent(`<!doctype html><html lang="uk"><head><meta charset="utf-8"><style>${CSS_BUNDLE}</style></head><body data-page-group="hr" class="${theme === 'dark' ? 'dark-mode' : ''}"></body></html>`);
     await page.evaluate(() => {
         window.AppState = { currentUser: { id: 1, role: 'creator', name: 'QA Creator' } };
-        window.canAccess = action => action === 'manage_staff';
+        window.canAccess = action => action === 'hr.staff.manage';
         window.apiVerifyToken = async () => ({ id: 1, role: 'creator', name: 'QA Creator' });
         window.showNotification = () => {};
         window.openProfessionWorkspace = options => {

--- a/tests/capability-parity-contract.test.js
+++ b/tests/capability-parity-contract.test.js
@@ -25,6 +25,7 @@ function loadFrontendResolver() {
         PAGE_CAPABILITY_ALIASES: catalog.pageAliases,
         ACTION_CAPABILITY_ALIASES: catalog.actionAliases,
         ACTION_LEGACY_KEYS: catalog.actionLegacyKeys,
+        ACTION_LEGACY_DENY_KEYS: catalog.actionLegacyDenyKeys,
         EXPLICIT_ALLOW_DISABLED_PAGES: new Set(catalog.explicitAllowDisabledPages),
         EXPLICIT_ALLOW_DISABLED_ACTIONS: new Set(catalog.explicitAllowDisabledActions),
         NON_DELEGABLE_ACTIONS: new Set(catalog.nonDelegableActions),
@@ -177,8 +178,8 @@ test('unknown keys fail closed in both runtimes', () => {
     assertParity({ role: 'creator' }, 'not_a_real_action', { type: 'action' });
 });
 
-test('Staff schedule, staff management, and Training onboarding honor canonical capability overrides', () => {
-    const capabilities = ['hr.schedule.view', 'hr.schedule.manage', 'hr.staff.view', 'hr.staff.manage', 'manage_staff'];
+test('Staff schedule, staff management, Hermes, and Training honor granular capability overrides', () => {
+    const capabilities = ['hr.schedule.view', 'hr.schedule.manage', 'hr.staff.view', 'hr.staff.manage', 'hermes.staff.manage', 'hermes.attendance.manage', 'hermes.schedule.manage', 'training.manage'];
 
     for (const role of ['manager', 'hr', 'admin']) {
         for (const capability of capabilities) {
@@ -187,11 +188,11 @@ test('Staff schedule, staff management, and Training onboarding honor canonical 
     }
 
     assert.equal(assertParity({ role: 'instructor' }, 'hr.schedule.view', { type: 'action' }).allowed, true, 'instructor can view the schedule');
-    for (const capability of ['hr.schedule.manage', 'hr.staff.view', 'hr.staff.manage', 'manage_staff']) {
+    for (const capability of ['hr.schedule.manage', 'hr.staff.view', 'hr.staff.manage', 'hermes.staff.manage', 'hermes.attendance.manage', 'hermes.schedule.manage', 'training.manage']) {
         assert.equal(assertParity({ role: 'instructor' }, capability, { type: 'action' }).allowed, false, `instructor must not receive ${capability} by default`);
     }
 
-    const allowed = { role: 'instructor', action_allowlist: ['hr.schedule.manage', 'hr.staff.manage', 'manage_staff'] };
+    const allowed = { role: 'instructor', action_allowlist: ['hr.schedule.manage', 'hr.staff.manage', 'hermes.staff.manage', 'hermes.attendance.manage', 'hermes.schedule.manage', 'training.manage'] };
     for (const capability of allowed.action_allowlist) {
         assert.equal(assertParity(allowed, capability, { type: 'action' }).allowed, true, `explicit allow must grant ${capability}`);
     }
@@ -200,6 +201,40 @@ test('Staff schedule, staff management, and Training onboarding honor canonical 
     for (const capability of capabilities) {
         assert.equal(assertParity(denied, capability, { type: 'action' }).allowed, false, `explicit deny must block ${capability}`);
     }
+});
+
+test('legacy manage_staff compatibility maps only to former granular consumers', () => {
+    const legacyAllowed = {
+        role: 'instructor',
+        action_allowlist: ['manage_staff']
+    };
+    for (const capability of ['hr.schedule.manage', 'hr.staff.manage', 'hermes.staff.manage', 'hermes.attendance.manage', 'hermes.schedule.manage', 'training.manage']) {
+        assert.equal(assertParity(legacyAllowed, capability, { type: 'action' }).allowed, true, `legacy manage_staff allow must preserve ${capability}`);
+    }
+    assert.equal(assertParity(legacyAllowed, 'manage_staff', { type: 'action' }).allowed, false, 'legacy manage_staff must remain a tombstone');
+
+    const legacyDenied = {
+        role: 'manager',
+        action_denylist: ['manage_staff']
+    };
+    for (const capability of ['hr.schedule.manage', 'hr.staff.manage', 'hermes.staff.manage', 'hermes.attendance.manage', 'hermes.schedule.manage', 'training.manage']) {
+        assert.equal(assertParity(legacyDenied, capability, { type: 'action' }).allowed, false, `legacy manage_staff deny must block ${capability}`);
+    }
+});
+
+test('legacy dead actions fail closed while manage_users deny revokes manage_accounts only as a deny alias', () => {
+    for (const key of ['cancel_booking', 'view_own']) {
+        const allowDecision = assertParity({ role: 'animator', action_allowlist: [key] }, key, { type: 'action' });
+        assert.deepEqual([allowDecision.allowed, allowDecision.reason], [false, 'unknown_capability']);
+        const denyDecision = assertParity({ role: 'creator', action_denylist: [key] }, key, { type: 'action' });
+        assert.deepEqual([denyDecision.allowed, denyDecision.reason], [false, 'unknown_capability']);
+    }
+
+    const legacyAllow = assertParity({ role: 'animator', action_allowlist: ['manage_users'] }, 'manage_accounts', { type: 'action' });
+    assert.deepEqual([legacyAllow.allowed, legacyAllow.reason], [false, 'no_matching_grant']);
+
+    const legacyDeny = assertParity({ role: 'director', action_denylist: ['manage_users'] }, 'manage_accounts', { type: 'action' });
+    assert.deepEqual([legacyDeny.allowed, legacyDeny.source, legacyDeny.reason], [false, 'explicit_deny', 'listed_in_explicit_deny']);
 });
 test('Finance management keeps creator, director and accountant parity with explicit overrides', () => {
     const capability = 'finance.manage';

--- a/tests/hermes-attendance-import.test.js
+++ b/tests/hermes-attendance-import.test.js
@@ -46,13 +46,13 @@ async function postJson(baseUrl, path, body, headers = {}) {
     return { status: response.status, data: await response.json() };
 }
 
-function routeActor(manageStaff = true) {
+function routeActor(manageAttendance = true) {
     return {
         id: 42,
         username: 'hermes.attendance',
         role: 'employee',
-        action_allowlist: manageStaff ? ['manage_staff'] : [],
-        action_denylist: manageStaff ? [] : ['manage_staff'],
+        action_allowlist: manageAttendance ? ['hermes.attendance.manage'] : [],
+        action_denylist: manageAttendance ? [] : ['hermes.attendance.manage'],
         business_contexts: ['event_genix'],
         default_business_context: 'event_genix'
     };
@@ -715,7 +715,7 @@ describe('Hermes arrival-sheet apply contract', () => {
 });
 
 describe('Hermes arrival-sheet route guards', () => {
-    it('allows manage_staff to preview without mutation confirmation and blocks actors without the permission', async () => {
+    it('allows hermes.attendance.manage to preview without mutation confirmation and blocks actors without the permission', async () => {
         let previewCalls = 0;
         const previewAttendanceImport = async (_db, body, options) => {
             previewCalls += 1;
@@ -757,7 +757,7 @@ describe('Hermes arrival-sheet route guards', () => {
                 previewPayload()
             );
             assert.equal(denied.status, 403);
-            assert.equal(denied.data.code, 'HERMES_MANAGE_STAFF_REQUIRED');
+            assert.equal(denied.data.code, 'HERMES_CAPABILITY_REQUIRED');
             assert.equal(previewCalls, 1);
         } finally {
             await close(deniedApp.server);

--- a/tests/hermes-auth.test.js
+++ b/tests/hermes-auth.test.js
@@ -424,7 +424,7 @@ describe('Hermes capabilities route auth', () => {
                 previewScheduleWrites: 0,
                 applyRequiresConfirmation: true,
                 applyRequiresIdempotencyKey: true,
-                applyRequiresManageStaff: true
+                applyRequiredCapability: 'hermes.schedule.manage'
             });
             assert.deepEqual(res.data.endpoints.attendance, {
                 preview: 'POST /api/hermes/attendance/preview',
@@ -432,13 +432,13 @@ describe('Hermes capabilities route auth', () => {
                 businessContext: 'event_genix',
                 maxPreviewRows: 100,
                 previewTtlMinutes: 30,
-                previewRequiresManageStaff: true,
+                previewRequiredCapability: 'hermes.attendance.manage',
                 previewAttendanceWrites: 0,
                 previewScheduleWrites: 0,
                 scheduleWrites: 0,
                 applyRequiresConfirmation: true,
                 applyRequiresIdempotencyKey: true,
-                applyRequiresManageStaff: true,
+                applyRequiredCapability: 'hermes.attendance.manage',
                 applyScheduleWrites: 0
             });
         });

--- a/tests/hermes-routes.test.js
+++ b/tests/hermes-routes.test.js
@@ -1350,7 +1350,7 @@ describe('Hermes read-only task routes', () => {
         assert.equal(res.data.endpoints.staffSchedule.apply, 'POST /api/hermes/staff-schedule/apply');
         assert.equal(res.data.endpoints.staffSchedule.applyRequiresConfirmation, true);
         assert.equal(res.data.endpoints.staffSchedule.applyRequiresIdempotencyKey, true);
-        assert.equal(res.data.endpoints.staffSchedule.applyRequiresManageStaff, true);
+        assert.equal(res.data.endpoints.staffSchedule.applyRequiredCapability, 'hermes.schedule.manage');
         assert.equal(res.data.endpoints.attendance.preview, 'POST /api/hermes/attendance/preview');
         assert.equal(res.data.endpoints.attendance.apply, 'POST /api/hermes/attendance/apply');
         assert.equal(res.data.endpoints.attendance.previewAttendanceWrites, 0);

--- a/tests/hermes-schedule-apply.test.js
+++ b/tests/hermes-schedule-apply.test.js
@@ -483,7 +483,7 @@ describe('Hermes schedule apply route safety', () => {
         }
     });
 
-    it('does not grant manage_staff to the Hermes actor automatically', async () => {
+    it('does not grant hermes.schedule.manage to the Hermes actor automatically', async () => {
         const fixture = await listenApplyApp({
             actor: {
                 id: 42,
@@ -501,7 +501,7 @@ describe('Hermes schedule apply route safety', () => {
                 validApplyHeaders('permission-1')
             );
             assert.equal(response.status, 403);
-            assert.equal(response.data.code, 'HERMES_MANAGE_STAFF_REQUIRED');
+            assert.equal(response.data.code, 'HERMES_CAPABILITY_REQUIRED');
             assert.equal(fixture.state.applyCalls, 0);
         } finally {
             await new Promise(resolve => fixture.server.close(resolve));

--- a/tests/hermes-schedule-preview.test.js
+++ b/tests/hermes-schedule-preview.test.js
@@ -354,7 +354,7 @@ describe('Hermes schedule OCR preview', () => {
                 authMode: 'x-api-key',
                 actorUserId: 42
             };
-            req.user = { id: 42, businessContexts: ['event_genix'] };
+            req.user = { id: 42, action_allowlist: ['hermes.schedule.manage'], businessContexts: ['event_genix'] };
             next();
         });
         app.use('/api/hermes', createHermesScheduleRouter({ pool: db }));

--- a/tests/hermes-schedule-routes.test.js
+++ b/tests/hermes-schedule-routes.test.js
@@ -271,7 +271,7 @@ describe('Hermes staff and schedule read routes', () => {
         assert.equal(wrongContext.data.code, 'HERMES_SCHEDULE_BUSINESS_CONTEXT_UNAVAILABLE');
     });
 
-    it('advertises schedule read, preview, staff create, and gated apply capabilities without granting manage_staff', async () => {
+    it('advertises schedule read, preview, staff create, and granular capability requirements without granting manage_staff', async () => {
         const response = await request(baseUrl, '/api/hermes/capabilities', {
             'x-api-key': env.HERMES_API_KEY
         });
@@ -288,7 +288,7 @@ describe('Hermes staff and schedule read routes', () => {
         assert.equal(response.data.endpoints.staff.create, 'POST /api/hermes/staff');
         assert.equal(response.data.endpoints.staff.createRequiresConfirmation, true);
         assert.equal(response.data.endpoints.staff.createRequiresIdempotencyKey, true);
-        assert.equal(response.data.endpoints.staff.createRequiresManageStaff, true);
+        assert.equal(response.data.endpoints.staff.createRequiredCapability, 'hermes.staff.manage');
         assert.equal(response.data.endpoints.staff.createScheduleWrites, 0);
         assert.equal(response.data.endpoints.staffSchedule.maxDateRangeDays, 31);
         assert.equal(response.data.endpoints.staffSchedule.preview, 'POST /api/hermes/staff-schedule/preview');
@@ -296,22 +296,23 @@ describe('Hermes staff and schedule read routes', () => {
         assert.equal(response.data.endpoints.staffSchedule.apply, 'POST /api/hermes/staff-schedule/apply');
         assert.equal(response.data.endpoints.staffSchedule.applyRequiresConfirmation, true);
         assert.equal(response.data.endpoints.staffSchedule.applyRequiresIdempotencyKey, true);
-        assert.equal(response.data.endpoints.staffSchedule.applyRequiresManageStaff, true);
+        assert.equal(response.data.endpoints.staffSchedule.applyRequiredCapability, 'hermes.schedule.manage');
         assert.equal(response.data.endpoints.attendance.preview, 'POST /api/hermes/attendance/preview');
+        assert.equal(response.data.endpoints.attendance.previewRequiredCapability, 'hermes.attendance.manage');
         assert.equal(response.data.endpoints.attendance.previewAttendanceWrites, 0);
         assert.equal(response.data.endpoints.attendance.previewScheduleWrites, 0);
         assert.equal(response.data.endpoints.attendance.scheduleWrites, 0);
         assert.equal(response.data.endpoints.attendance.apply, 'POST /api/hermes/attendance/apply');
         assert.equal(response.data.endpoints.attendance.applyRequiresConfirmation, true);
         assert.equal(response.data.endpoints.attendance.applyRequiresIdempotencyKey, true);
-        assert.equal(response.data.endpoints.attendance.applyRequiresManageStaff, true);
+        assert.equal(response.data.endpoints.attendance.applyRequiredCapability, 'hermes.attendance.manage');
         assert.equal(response.data.endpoints.attendance.applyScheduleWrites, 0);
     });
 
     it('creates a staff member through Hermes with clear no-schedule side effects', async () => {
         const createPoolWithManageStaff = createPool({
             actor: actorRow({
-                action_allowlist: ['manage_staff'],
+                action_allowlist: ['hermes.staff.manage'],
                 action_denylist: []
             }),
             createdStaffRow: {
@@ -404,7 +405,7 @@ describe('Hermes staff and schedule read routes', () => {
 
     it('requires Hermes integration id, confirmation, idempotency, and API-key auth for staff create', async () => {
         const guardedPool = createPool({
-            actor: actorRow({ action_allowlist: ['manage_staff'], action_denylist: [] })
+            actor: actorRow({ action_allowlist: ['hermes.staff.manage'], action_denylist: [] })
         });
         const { server: guardedServer, baseUrl: guardedBaseUrl } = await listenHermesTestApp(guardedPool, env);
         const body = {
@@ -453,7 +454,7 @@ describe('Hermes staff and schedule read routes', () => {
         }
     });
 
-    it('rejects a Hermes actor without manage_staff before staff queries', async () => {
+    it('rejects a Hermes actor without hermes.staff.manage before staff queries', async () => {
         const deniedPool = createPool();
         const { server: deniedServer, baseUrl: deniedBaseUrl } = await listenHermesTestApp(deniedPool, env);
         try {
@@ -472,7 +473,7 @@ describe('Hermes staff and schedule read routes', () => {
                 }
             });
             assert.equal(response.status, 403);
-            assert.equal(response.data.code, 'HERMES_MANAGE_STAFF_REQUIRED');
+            assert.equal(response.data.code, 'HERMES_CAPABILITY_REQUIRED');
             assert.equal(deniedPool.calls.some(call => /FROM staff|INSERT INTO staff/.test(call.sql)), false);
         } finally {
             await close(deniedServer);
@@ -481,7 +482,7 @@ describe('Hermes staff and schedule read routes', () => {
 
     it('rejects normalized duplicate staff names with a sanitized existing envelope', async () => {
         const duplicatePool = createPool({
-            actor: actorRow({ action_allowlist: ['manage_staff'], action_denylist: [] }),
+            actor: actorRow({ action_allowlist: ['hermes.staff.manage'], action_denylist: [] }),
             duplicateRows: [{
                 id: 321,
                 name: 'Плющкіт',
@@ -532,7 +533,7 @@ describe('Hermes staff and schedule read routes', () => {
 
     it('accepts snake_case profession aliases and strips @ from Telegram username', async () => {
         const aliasPool = createPool({
-            actor: actorRow({ action_allowlist: ['manage_staff'], action_denylist: [] }),
+            actor: actorRow({ action_allowlist: ['hermes.staff.manage'], action_denylist: [] }),
             createdStaffRow: {
                 id: 1000,
                 name: 'Плющкіт Alias',
@@ -576,7 +577,7 @@ describe('Hermes staff and schedule read routes', () => {
     it('keeps staff creation separate from schedule changes', async () => {
         const createPoolWithManageStaff = createPool({
             actor: actorRow({
-                action_allowlist: ['manage_staff'],
+                action_allowlist: ['hermes.staff.manage'],
                 action_denylist: []
             })
         });

--- a/tests/hermes-staff-schedule.test.js
+++ b/tests/hermes-staff-schedule.test.js
@@ -43,7 +43,7 @@ test('Hermes staff schedule capabilities expose the complete public worker contr
         defaultIncludeFreelance: false,
         createRequiresConfirmation: true,
         createRequiresIdempotencyKey: true,
-        createRequiresManageStaff: true,
+        createRequiredCapability: 'hermes.staff.manage',
         createScheduleWrites: 0
     });
     assert.deepEqual(capabilities.endpoints.staffSchedule, {
@@ -58,7 +58,7 @@ test('Hermes staff schedule capabilities expose the complete public worker contr
         previewScheduleWrites: 0,
         applyRequiresConfirmation: true,
         applyRequiresIdempotencyKey: true,
-        applyRequiresManageStaff: true
+        applyRequiredCapability: 'hermes.schedule.manage'
     });
     assert.deepEqual(capabilities.endpoints.attendance, {
         preview: 'POST /api/hermes/attendance/preview',
@@ -66,13 +66,13 @@ test('Hermes staff schedule capabilities expose the complete public worker contr
         businessContext: 'event_genix',
         maxPreviewRows: 100,
         previewTtlMinutes: 30,
-        previewRequiresManageStaff: true,
+        previewRequiredCapability: 'hermes.attendance.manage',
         previewAttendanceWrites: 0,
         previewScheduleWrites: 0,
         scheduleWrites: 0,
         applyRequiresConfirmation: true,
         applyRequiresIdempotencyKey: true,
-        applyRequiresManageStaff: true,
+        applyRequiredCapability: 'hermes.attendance.manage',
         applyScheduleWrites: 0
     });
 });

--- a/tests/hr-org-node-modal-dismiss.test.js
+++ b/tests/hr-org-node-modal-dismiss.test.js
@@ -47,7 +47,7 @@ function createHarness() {
         addListener() {},
         removeListener() {}
     });
-    window.canAccess = action => action === 'manage_staff' && window.__canManageStructure;
+    window.canAccess = action => action === 'hr.staff.manage' && window.__canManageStructure;
 
     const uiCode = fs.readFileSync(path.join(ROOT, 'js', 'ui.js'), 'utf8');
     const hrCode = fs.readFileSync(path.join(ROOT, 'js', 'hr-page.js'), 'utf8');

--- a/tests/hr-org-tree-regressions.test.js
+++ b/tests/hr-org-tree-regressions.test.js
@@ -26,7 +26,7 @@ function createHarness({ editable = true, mobile = false } = {}) {
     window.console = console;
     window.__canManageStructure = editable;
     window.__hrOrgMobile = mobile;
-    window.canAccess = action => action === 'manage_staff' && window.__canManageStructure;
+    window.canAccess = action => action === 'hr.staff.manage' && window.__canManageStructure;
     window.showNotification = () => {};
     window.apiVerifyToken = async () => ({ id: 1, role: 'creator', name: 'Tester' });
     window.openProfessionWorkspace = options => {

--- a/tests/permission-registry-contract.test.js
+++ b/tests/permission-registry-contract.test.js
@@ -92,12 +92,13 @@ function assertEntryShape(entry, type) {
     });
 }
 
-test('registry describes exactly the current 43 canonical page and 41 action keys', () => {
+test('registry describes the current page catalog and active action contract', () => {
     const backend = loadBackendAuth();
     const pageKeys = registry.PAGE_PERMISSIONS.map(entry => entry.key);
-    const actionKeys = registry.ACTION_PERMISSIONS.map(entry => entry.key);
+    const actionKeys = registry.ACTION_PERMISSIONS.filter(entry => entry.deprecated !== true).map(entry => entry.key);
 
     assert.equal(pageKeys.length, 43);
+    assert.equal(registry.ACTION_PERMISSIONS.length, 45);
     assert.equal(actionKeys.length, 41);
     assertUnique(pageKeys, 'page permission keys');
     assertUnique(actionKeys, 'action permission keys');
@@ -109,19 +110,23 @@ test('registry describes exactly the current 43 canonical page and 41 action key
         assert.equal(typeof entry.canonicalPath, 'string', `page ${entry.key}: canonicalPath must be a string`);
         assert.deepEqual(sorted(entry.defaultRoles), sorted(backend.PAGE_ACCESS[entry.key]), `page ${entry.key}: defaultRoles drift`);
     }
-    for (const entry of registry.ACTION_PERMISSIONS) {
+    for (const entry of registry.ACTION_PERMISSIONS.filter(item => item.deprecated !== true)) {
         assertEntryShape(entry, 'action');
         assert.deepEqual(sorted(entry.defaultRoles), sorted(backend.ACTION_PERMISSIONS[entry.key]), `action ${entry.key}: defaultRoles drift`);
     }
 
-    const nonDelegable = registry.ACTION_PERMISSIONS.filter(entry => entry.delegable === false).map(entry => entry.key);
+    const nonDelegable = registry.ACTION_PERMISSIONS.filter(entry => entry.deprecated !== true && entry.delegable === false).map(entry => entry.key);
     assert.deepEqual(sorted(nonDelegable), sorted(Array.from(backend.NON_DELEGABLE_ACTIONS)), 'non-delegable action drift');
 });
 
 test('public page metadata is a complete safe projection of the registry', () => {
     const publicPages = registry.getPublicPagePermissionMetadata();
-    assert.equal(publicPages.length, registry.PAGE_PERMISSIONS.length);
-    assert.deepEqual(sorted(publicPages.map(entry => entry.key)), sorted(registry.PAGE_PERMISSIONS.map(entry => entry.key)));
+    const configurablePages = registry.PAGE_PERMISSIONS.filter(entry => entry.deprecated !== true && entry.configurable !== false);
+    assert.equal(publicPages.length, configurablePages.length);
+    assert.deepEqual(sorted(publicPages.map(entry => entry.key)), sorted(configurablePages.map(entry => entry.key)));
+    for (const key of ['/dashboard', '/profile', '/game', '/quiz', '/room', '/shop']) {
+        assert.equal(publicPages.some(entry => entry.key === key), false, key + ' must not create a role toggle');
+    }
     assertUnique(publicPages.map(entry => entry.key), 'public page metadata keys');
 
     for (const entry of publicPages) {
@@ -197,7 +202,7 @@ test('aliases canonicalize to known permission keys', () => {
 });
 
 test('every active action has a server-side enforcement consumer or an explicit deprecated marker', () => {
-    for (const entry of registry.ACTION_PERMISSIONS) {
+    for (const entry of registry.ACTION_PERMISSIONS.filter(item => item.deprecated !== true)) {
         const hasSpecificBackendEnforcement = entry.backendConsumers.some(consumer => consumer.enforces === true);
         const hasActionApiConsumer = entry.apiConsumers.some(consumer => consumer.enforcement === 'action');
         const hasServerEnforcement = hasSpecificBackendEnforcement || hasActionApiConsumer;
@@ -217,7 +222,7 @@ test('every active capability is linked to both a frontend and backend consumer'
 });
 
 test('deprecated toggles are hidden and canonical pages have one key', () => {
-    const deprecatedKeys = ['cancel_booking', 'view_own', 'manage_users'];
+    const deprecatedKeys = ['cancel_booking', 'view_own', 'manage_users', 'manage_staff'];
     deprecatedKeys.forEach(key => assert.equal(registry.ACTION_PERMISSION_BY_KEY[key]?.deprecated, true, `${key} must remain compatibility-only`));
     ['view_revenue', 'manage_settings', 'export_data'].forEach(key => {
         const action = registry.ACTION_PERMISSION_BY_KEY[key];
@@ -230,6 +235,9 @@ test('deprecated toggles are hidden and canonical pages have one key', () => {
     const accountUi = fs.readFileSync(path.join(ROOT, 'js', 'hr-page.js'), 'utf8');
     assert.match(userRoutes, /filter\(action => action\.deprecated !== true\)/);
     assert.match(accountUi, /filter\(item => item && item\.deprecated !== true\)/);
+    for (const key of deprecatedKeys) {
+        assert.equal(accountUi.includes(`key: '${key}'`), false, `${key} must not be hardcoded as an editor action toggle`);
+    }
 
     ['/kleshnya', '/leads', '/art-director', '/analytics', '/settings'].forEach(key => {
         assert.equal(registry.PAGE_PERMISSION_BY_KEY[key], undefined, `${key} must not be a standalone page toggle`);
@@ -238,6 +246,25 @@ test('deprecated toggles are hidden and canonical pages have one key', () => {
     assert.equal(registry.canonicalizePageKey('/leads'), '/sales-funnel');
     assert.equal(registry.canonicalizePageKey('/art-director'), '/art');
     assert.equal(registry.canonicalizePageKey('/analytics'), '/finance');
+});
+
+test('granular manage_staff replacements are active and legacy key is compatibility-only', () => {
+    const granular = ['hr.staff.manage', 'hr.schedule.manage', 'hermes.staff.manage', 'hermes.attendance.manage', 'hermes.schedule.manage', 'training.manage'];
+    for (const key of granular) {
+        const action = registry.ACTION_PERMISSION_BY_KEY[key];
+        assert.equal(action?.deprecated, false, `${key} must be active`);
+        assert.equal(action?.legacyKeys.includes('manage_staff'), true, `${key} must preserve stored manage_staff compatibility`);
+        assert.ok(action.backendConsumers.some(consumer => consumer.enforces === true), `${key} must have executable backend enforcement metadata`);
+    }
+    assert.equal(registry.ACTION_PERMISSION_BY_KEY.manage_staff.deprecated, true);
+    assert.equal(registry.ACTION_PERMISSION_BY_KEY.manage_staff.configurable, false);
+
+    const hermesSchedule = fs.readFileSync(path.join(ROOT, 'routes', 'hermes-schedule.js'), 'utf8');
+    const training = fs.readFileSync(path.join(ROOT, 'routes', 'training.js'), 'utf8');
+    const onboarding = fs.readFileSync(path.join(ROOT, 'services', 'hermesStaffAccountOnboarding.js'), 'utf8');
+    assert.doesNotMatch(hermesSchedule, /canUseAction\(req\.user, 'manage_staff'\)/);
+    assert.doesNotMatch(training, /canUseAction\(req\.user, 'manage_staff'\)/);
+    assert.doesNotMatch(onboarding, /canUseAction\(actor, 'manage_staff'\)/);
 });
 
 test('critical action API inventory matches literal route guards', () => {

--- a/tests/training-course-progress.test.js
+++ b/tests/training-course-progress.test.js
@@ -86,7 +86,7 @@ async function withTrainingApp(options, run) {
             next();
         },
         requireMinRole: () => (_req, _res, next) => next(),
-        canUseAction: (_user, action) => action === 'manage_staff' && options.canManageStaff !== false
+        canUseAction: (_user, action) => action === 'training.manage' && options.canManageStaff !== false
     });
     installMock('../utils/logger', {
         createLogger: () => ({ error: () => {}, warn: () => {}, info: () => {} })
@@ -361,7 +361,7 @@ test('repeated seed completion preserves original completion actor and notes', a
     });
 });
 
-test('seed completion is read-only without manage_staff capability', async () => {
+test('seed completion is read-only without training.manage capability', async () => {
     await withTrainingApp({
         canManageStaff: false,
         clientQuery: async sql => {


### PR DESCRIPTION
## Summary
- Mark legacy dead actions as non-configurable tombstones and keep old stored arrays fail-closed/compatible.
- Split generic manage_staff into granular HR, Hermes, and Training capabilities.
- Remove non-configurable personal pages from public toggle definitions while preserving physical routes/session behavior.
- Update Hermes capabilities metadata and tests to expose granular capability requirements.

## Verification
- npm run check:runtime
- npm run check:timeline-protected-surface
- npm run check:access
- npm run check:auth-boundary
- focused permission/Hermes/Training tests
- npm test

## Safety
- No DB migration or production array cleanup.
- No booking/timeline protected source changes.
- Old worktree diff was preserved as a safety patch and not reset/deleted.