### PR TITLE
Align live QA with training.manage

### DIFF
--- a/scripts/live-authenticated-surface-qa.js
+++ b/scripts/live-authenticated-surface-qa.js
@@ -313,9 +313,9 @@ async function runBrowserChecks(base, config, report) {
         await expectVisible(page, 'button.training-tab[data-tab="onboarding"]', 'qa_training_onboarding_tab_missing');
         await page.locator('button.training-tab[data-tab="onboarding"]').click();
         await expectVisible(page, '#trainingOnboardingList', 'qa_training_onboarding_missing');
-        await waitFor(page, () => typeof window.canUseAction === 'function' && window.canUseAction('manage_staff'), 'qa_training_capability_mismatch');
+        await waitFor(page, () => typeof window.canUseAction === 'function' && window.canUseAction('training.manage'), 'qa_training_capability_mismatch');
         await expectVisible(page, '#trainingStartOnboarding:not(.hidden)', 'qa_training_management_control_missing');
-        report.routes.training = { ok: true, manageStaff: true };
+        report.routes.training = { ok: true, trainingManage: true };
 
         await goto(page, base, '/finance', 'qa_finance_open_failed');
         await expectVisible(page, '#addTransactionBtn', 'qa_finance_management_control_missing');

--- a/tests/live-authenticated-surface-qa.test.js
+++ b/tests/live-authenticated-surface-qa.test.js
@@ -54,6 +54,8 @@ test('authenticated live QA is a manual gate with a role restoration contract', 
     assert.match(runnerSource, /QA_CREATOR_LEASE_SECONDS/);
     assert.match(runnerSource, /window\.__eventGenixLiveQaReadOnly = true/);
     assert.match(authSource, /window\.__eventGenixLiveQaReadOnly === true/);
+    assert.match(runnerSource, /window\.canUseAction\('training\.manage'\)/);
+    assert.doesNotMatch(runnerSource, /window\.canUseAction\('manage_staff'\)/);
     assert.doesNotMatch(runnerSource, /KNOWN_AUTOMATIC_BLOCKED_PATHS/);
     assert.doesNotMatch(runnerSource, /wallet\/daily-login/);
     assert.match(runnerSource, /browserMutations\.length === 0/);


### PR DESCRIPTION
## Summary
- update manual live authenticated QA to validate training.manage instead of deprecated manage_staff
- add contract assertion preventing manage_staff from returning to the Training live QA path

## Verification
- npm run test:live-authenticated-qa-contract
- npm run qa:live:authenticated

Production runtime behavior is unchanged.